### PR TITLE
[smjs document replace] fixed property location, replace and writel

### DIFF
--- a/src/document/document.h
+++ b/src/document/document.h
@@ -210,6 +210,7 @@ struct document {
 	struct uri_list ecmascript_imports;
 	/** used by setTimeout */
 	timer_id_T timeout;
+	int ecmascript_counter;
 #endif
 #ifdef CONFIG_CSS
 	/** @todo FIXME: We should externally maybe using cache_entry store the

--- a/src/ecmascript/spidermonkey.c
+++ b/src/ecmascript/spidermonkey.c
@@ -400,6 +400,12 @@ spidermonkey_check_for_exception(JSContext *ctx) {
 			}
 			//JS_ClearPendingException(ctx);
 		}
+		/* This absorbs all following exceptions
+		 * probably not the 100% correct solution
+		 * to the javascript error handling but
+		 * at least there isn't too much click-bait
+		 * on each site with javascript enabled */
+		JS_ClearPendingException(ctx);
 	}
 
 }

--- a/src/ecmascript/spidermonkey/document.c
+++ b/src/ecmascript/spidermonkey/document.c
@@ -485,7 +485,7 @@ document_write_do(JSContext *ctx, unsigned int argc, JS::Value *rval, int newlin
 		for (int i=0;i<argc;++i) 
 		{
 
-			code=jshandle_value_to_char_string(&code,ctx,&args[i]);
+			jshandle_value_to_char_string(&code,ctx,&args[i]);
 		}
 	
 		if (newline) 
@@ -623,8 +623,8 @@ document_replace(JSContext *ctx, unsigned int argc, JS::Value *vp)
 	struct string needle;
 	struct string heystack;
 
-	needle = jshandle_value_to_char_string(&needle, ctx, &args[0]);
-	heystack = jshandle_value_to_char_string(&heystack, ctx, &args[1]);
+	jshandle_value_to_char_string(&needle, ctx, &args[0]);
+	jshandle_value_to_char_string(&heystack, ctx, &args[1]);
 
 	//DBG("doc replace %s %s\n", needle.source, heystack.source);
 

--- a/src/ecmascript/spidermonkey/document.c
+++ b/src/ecmascript/spidermonkey/document.c
@@ -480,6 +480,8 @@ document_write_do(JSContext *ctx, unsigned int argc, JS::Value *rval, int newlin
 
 	struct string code;
 
+	init_string(&code);
+
 	if (argc >= 1)
 	{
 		for (int i=0;i<argc;++i) 
@@ -527,6 +529,7 @@ document_write_do(JSContext *ctx, unsigned int argc, JS::Value *rval, int newlin
 	set_led_value(interpreter->vs->doc_view->session->status.ecmascript_led, 'J');
 #endif
 
+	done_string(&code);
 	args.rval().setBoolean(false);
 
 	return true;
@@ -559,9 +562,8 @@ string_replace(struct string *res, struct string *inp, struct string *what, stru
 	
 	init_string(&tmp);
 	init_string(&tmp2);
-	init_string(res);
+
 	add_to_string(&tmp,inp->source);
-	
 	
 	head = tmp.source;
 	int  count = 0;
@@ -598,6 +600,10 @@ string_replace(struct string *res, struct string *inp, struct string *what, stru
 		head = tmp.source;
 	}
 	add_to_string(res,tmp.source);
+
+	done_string(&tmp);
+	done_string(&tmp2);
+
 }
 
 /* @document_funcs{"replace"} */
@@ -623,6 +629,9 @@ document_replace(JSContext *ctx, unsigned int argc, JS::Value *vp)
 	struct string needle;
 	struct string heystack;
 
+	init_string(&needle);
+	init_string(&heystack);
+
 	jshandle_value_to_char_string(&needle, ctx, &args[0]);
 	jshandle_value_to_char_string(&heystack, ctx, &args[1]);
 
@@ -643,6 +652,7 @@ document_replace(JSContext *ctx, unsigned int argc, JS::Value *vp)
 		add_to_string(&f_data,f->data);
 
 		struct string nu_str;
+		init_string(&nu_str);
 		string_replace(&nu_str,&f_data,&needle,&heystack);
 		nu_len=nu_str.length;
 		delete_entry_content(cached);
@@ -656,6 +666,9 @@ document_replace(JSContext *ctx, unsigned int argc, JS::Value *vp)
 		document->ecmascript_counter++;
 		//DBG("doc replace %s %s\n", needle.source, heystack.source);
 	}
+
+	done_string(&needle);
+	done_string(&heystack);
 
 	args.rval().setBoolean(true);
 

--- a/src/ecmascript/spidermonkey/localstorage.c
+++ b/src/ecmascript/spidermonkey/localstorage.c
@@ -193,10 +193,8 @@ localstorage_setitem(JSContext *ctx, unsigned int argc, JS::Value *vp)
 	       return(true);
         }
 
-	//key = jshandle_value_to_char_string(ctx,&args[0]);
-	key = jshandle_value_to_char_string(&key,ctx,&args[0]);
-	//val = jshandle_value_to_char_string(ctx,&args[1]);
-	val = jshandle_value_to_char_string(&val,ctx,&args[1]);
+	jshandle_value_to_char_string(&key,ctx,&args[0]);
+	jshandle_value_to_char_string(&val,ctx,&args[1]);
 
 	saveToStorage(key.source,val.source);
 

--- a/src/ecmascript/spidermonkey/localstorage.c
+++ b/src/ecmascript/spidermonkey/localstorage.c
@@ -173,10 +173,11 @@ localstorage_getitem(JSContext *ctx, unsigned int argc, JS::Value *vp)
 static bool
 localstorage_setitem(JSContext *ctx, unsigned int argc, JS::Value *vp)
 {
-	//unsigned char *key;
 	struct string key;
-        //unsigned char *val;
 	struct string val;
+
+	init_string(&key);
+	init_string(&val);
 
 	JSCompartment *comp = js::GetContextCompartment(ctx);
 
@@ -205,6 +206,9 @@ localstorage_setitem(JSContext *ctx, unsigned int argc, JS::Value *vp)
 	set_led_value(interpreter->vs->doc_view->session->status.ecmascript_led, 'J');
 #endif
 	args.rval().setBoolean(true);
+
+	done_string(&key);
+	done_string(&val);
 
 	return(true);
 }

--- a/src/ecmascript/spidermonkey/localstorage.c
+++ b/src/ecmascript/spidermonkey/localstorage.c
@@ -173,6 +173,9 @@ localstorage_getitem(JSContext *ctx, unsigned int argc, JS::Value *vp)
 static bool
 localstorage_setitem(JSContext *ctx, unsigned int argc, JS::Value *vp)
 {
+	unsigned char *key;
+        unsigned char *val;
+
 	JSCompartment *comp = js::GetContextCompartment(ctx);
 
 	if (!comp)
@@ -188,8 +191,9 @@ localstorage_setitem(JSContext *ctx, unsigned int argc, JS::Value *vp)
 	       return(true);
         }
 
-        unsigned char *key = JS_EncodeString(ctx, args[0].toString());
-        unsigned char *val = JS_EncodeString(ctx, args[1].toString());
+	key = jshandle_value_to_char_string(ctx,&args[0]);
+	val = jshandle_value_to_char_string(ctx,&args[1]);
+
 	saveToStorage(key,val);
 	//DBG("%s %s\n", key, val);
 

--- a/src/ecmascript/spidermonkey/localstorage.c
+++ b/src/ecmascript/spidermonkey/localstorage.c
@@ -173,8 +173,10 @@ localstorage_getitem(JSContext *ctx, unsigned int argc, JS::Value *vp)
 static bool
 localstorage_setitem(JSContext *ctx, unsigned int argc, JS::Value *vp)
 {
-	unsigned char *key;
-        unsigned char *val;
+	//unsigned char *key;
+	struct string key;
+        //unsigned char *val;
+	struct string val;
 
 	JSCompartment *comp = js::GetContextCompartment(ctx);
 
@@ -191,10 +193,13 @@ localstorage_setitem(JSContext *ctx, unsigned int argc, JS::Value *vp)
 	       return(true);
         }
 
-	key = jshandle_value_to_char_string(ctx,&args[0]);
-	val = jshandle_value_to_char_string(ctx,&args[1]);
+	//key = jshandle_value_to_char_string(ctx,&args[0]);
+	key = jshandle_value_to_char_string(&key,ctx,&args[0]);
+	//val = jshandle_value_to_char_string(ctx,&args[1]);
+	val = jshandle_value_to_char_string(&val,ctx,&args[1]);
 
-	saveToStorage(key,val);
+	saveToStorage(key.source,val.source);
+
 	//DBG("%s %s\n", key, val);
 
 

--- a/src/ecmascript/spidermonkey/util.h
+++ b/src/ecmascript/spidermonkey/util.h
@@ -9,8 +9,7 @@ static void string_to_jsval(JSContext *ctx, JS::Value *vp, char *string);
 static void astring_to_jsval(JSContext *ctx, JS::Value *vp, char *string);
 
 static int jsval_to_boolean(JSContext *ctx, JS::Value *vp);
-//static unsigned char * jshandle_value_to_char_string(JSContext *ctx, JS::MutableHandleValue *obj);
-static struct string jshandle_value_to_char_string(struct string *string, JSContext *ctx, JS::MutableHandleValue *obj);
+static void jshandle_value_to_char_string(struct string *string, JSContext *ctx, JS::MutableHandleValue *obj);
 
 
 
@@ -44,8 +43,7 @@ jsval_to_boolean(JSContext *ctx, JS::Value *vp)
 /* Since SpiderMonkey 52 the Mutable Handle Object
  * is different for String and Number and must be
  * handled accordingly */
-//unsigned char *
-struct string 
+void
 jshandle_value_to_char_string(struct string *string,JSContext *ctx, JS::MutableHandleValue *obj)
 {
 	init_string(string);
@@ -62,7 +60,6 @@ jshandle_value_to_char_string(struct string *string,JSContext *ctx, JS::MutableH
 		int tmpinta = obj->toNumber();
 		add_format_to_string(string, "%d", tmpinta);
 	}
-	return(*string);
 }
 
 #endif

--- a/src/ecmascript/spidermonkey/util.h
+++ b/src/ecmascript/spidermonkey/util.h
@@ -9,6 +9,7 @@ static void string_to_jsval(JSContext *ctx, JS::Value *vp, char *string);
 static void astring_to_jsval(JSContext *ctx, JS::Value *vp, char *string);
 
 static int jsval_to_boolean(JSContext *ctx, JS::Value *vp);
+static unsigned char * jshandle_value_to_char_string(JSContext *ctx, JS::MutableHandleValue *obj);
 
 
 
@@ -36,6 +37,34 @@ jsval_to_boolean(JSContext *ctx, JS::Value *vp)
 {
 	JS::RootedValue r_vp(ctx, *vp);
 	return (int)r_vp.toBoolean();
+}
+
+
+/* Since SpiderMonkey 52 the Mutable Handle Object
+ * is different for String and Number and must be
+ * handled accordingly */
+unsigned char *
+jshandle_value_to_char_string(JSContext *ctx, JS::MutableHandleValue *obj)
+{
+	unsigned char *ret;
+	ret = stracpy("");
+	if (obj->isString())
+	{
+		ret = JS_EncodeString(ctx, obj->toString());
+	} else if (obj->isNumber())
+	{
+		int tmpinta = obj->toNumber();
+		char tmpints[256]="";
+		sprintf(tmpints,"%d",tmpinta);
+		add_to_strn(&ret,tmpints);
+	} else if (obj->isBoolean())
+	{
+		int tmpinta = obj->toBoolean();
+		char tmpints[16]="";
+		sprintf(tmpints,"%d",tmpinta);
+		add_to_strn(&ret,tmpints);
+	}
+	return(ret);
 }
 
 #endif

--- a/src/ecmascript/spidermonkey/util.h
+++ b/src/ecmascript/spidermonkey/util.h
@@ -9,7 +9,8 @@ static void string_to_jsval(JSContext *ctx, JS::Value *vp, char *string);
 static void astring_to_jsval(JSContext *ctx, JS::Value *vp, char *string);
 
 static int jsval_to_boolean(JSContext *ctx, JS::Value *vp);
-static unsigned char * jshandle_value_to_char_string(JSContext *ctx, JS::MutableHandleValue *obj);
+//static unsigned char * jshandle_value_to_char_string(JSContext *ctx, JS::MutableHandleValue *obj);
+static struct string jshandle_value_to_char_string(struct string *string, JSContext *ctx, JS::MutableHandleValue *obj);
 
 
 
@@ -43,28 +44,25 @@ jsval_to_boolean(JSContext *ctx, JS::Value *vp)
 /* Since SpiderMonkey 52 the Mutable Handle Object
  * is different for String and Number and must be
  * handled accordingly */
-unsigned char *
-jshandle_value_to_char_string(JSContext *ctx, JS::MutableHandleValue *obj)
+//unsigned char *
+struct string 
+jshandle_value_to_char_string(struct string *string,JSContext *ctx, JS::MutableHandleValue *obj)
 {
-	unsigned char *ret;
-	ret = stracpy("");
+	init_string(string);
+	
 	if (obj->isString())
 	{
-		ret = JS_EncodeString(ctx, obj->toString());
+		add_to_string(string,JS_EncodeString(ctx, obj->toString()));
 	} else if (obj->isNumber())
 	{
 		int tmpinta = obj->toNumber();
-		char tmpints[256]="";
-		sprintf(tmpints,"%d",tmpinta);
-		add_to_strn(&ret,tmpints);
+		add_format_to_string(string, "%d", tmpinta);
 	} else if (obj->isBoolean())
 	{
-		int tmpinta = obj->toBoolean();
-		char tmpints[16]="";
-		sprintf(tmpints,"%d",tmpinta);
-		add_to_strn(&ret,tmpints);
+		int tmpinta = obj->toNumber();
+		add_format_to_string(string, "%d", tmpinta);
 	}
-	return(ret);
+	return(*string);
 }
 
 #endif

--- a/test/ecmascript/arithmetics.html
+++ b/test/ecmascript/arithmetics.html
@@ -1,0 +1,173 @@
+
+<head>
+<title>
+ARITHMETICS
+</title>
+<style>
+* {
+  font-size: 24px;
+}
+body {
+  background: black;
+}
+input {
+  font-family: monospace; 
+  background: black;
+  color: gray; 
+  border: 0px;
+}
+*:focus {
+  outline: none !important;
+  border: 0px; 
+}
+</style>
+</head>
+<body>
+<font color="gray">
+<form id="core" name="core" action="arithmetics.html">
+<pre>
+                               
+   <font color="yellow">#x#</font>
+  +<font color="yellow">#z#</font>
+ ---------
+
+  = <input autocomplete="off" autofocus name="i" value="" size="2">
+
+Control:   <font color="#bbbbbb">#f#</font>
+Score:  <font color="green">#s#</font>
+
+<input name="tm" value="#NOW#" size="3" type="hidden">
+<input type="submit" size="2" value="o">
+</pre>
+</form>
+<script>
+
+// CHANGE THE MAX_NUMBER HERE
+var MAX_NUMBER=10;
+
+function lpad(number,sz) {
+  if (sz==undefined) {
+    sz=4;
+  }
+  maxnum=Math.pow(10,sz)-1;
+  str_shift=Array(sz).join(" ");
+  if (number<=maxnum) { number = (str_shift+number).slice(-sz); }
+  ///console.log(number+" "+maxnum+" "+sz+"|"+str_shift+"|");
+  return number;
+}
+function doc_replace(needle,heystack) {
+  if (document.replace) {
+    document.replace(needle,heystack);
+  } else {
+    document.getElementsByTagName("html")[0].innerHTML=document.getElementsByTagName("html")[0].innerHTML.replace(needle,heystack);
+  }
+}
+function findGetParameter(paramName) {
+  var res = null;
+  loc=document.location.toString();
+  //console.log(loc);
+  elems=loc.split('?')[1];
+  if (!elems) { return(res); }
+  //console.log(elems);
+  par=elems.split('&');
+  for (i=0;i<par.length;i++) {
+    key=par[i].split('=');
+    if (key[0]==paramName) {
+      res=key[1];
+      break;
+      //console.log("key: "+key[0]+" val: "+key[1]);
+    }
+  }
+  return(res);
+}
+function proc_var(prnname,lodname,savename,saveval) {
+  if (lodname!=null) {
+    x = localStorage.getItem(lodname);
+    //console.log("Loading "+lodname+" val: "+x);
+  } else {
+    x=saveval;
+  }
+  if (x==null || !x) { x="@"+prnname+"@"; }
+  doc_replace('#'+prnname+'#',lpad(x));
+  if (savename!==undefined) {
+    localStorage.setItem(prnname,saveval);
+    //console.log("Saving "+prnname+" val: "+saveval);
+  }
+  return(x);
+}
+function get_rand_var(xname) {
+  x = Math.round(Math.random()*(MAX_NUMBER));
+  localStorage.setItem(xname,x);
+  doc_replace('#'+xname+'#',lpad(x));
+  return(x);
+}
+function prepare_task() { 
+  // print and get input begin
+  // get previous random number
+  a=proc_var('a','x');
+  z=proc_var('u','z');
+  // generate random number 
+  x=get_rand_var('x');
+  y=get_rand_var('z');
+  // get previous user input 
+  p=proc_var('p','i');
+  return [a,z];
+}
+function get_user_input() {
+  // get user input 
+  var i = findGetParameter("i");
+  proc_var('i',null,'i',i);
+  // print and get input end
+  return(i);
+}
+function evaluate_result(a,z,i) {
+  // feedback loop begin
+  correctAnswer=0;
+  //console.log("z: " + z + " a: " + a + " i: " + i);
+  if (Number(z) + Number(a) == Number(i)) { // user inputs prev number
+    doc_replace('#f#',' OK');
+    doc_replace('#bbbbbb','#00ee00');
+    correctAnswer=1;
+  } else {
+    doc_replace('#f#','NOK');
+    doc_replace('#bbbbbb','#ee0000');
+  }
+  // feedback loop end
+  return(correctAnswer);
+}
+function updateScore(gain) {
+  keyname="score";
+  score=localStorage.getItem(keyname);
+  if (!score || score==null 
+     || typeof(score)=="NaN"
+     || score=="NaN"
+  ) {
+    score=0;
+  }
+  score=Number(score);
+  score+=gain;
+  localStorage.setItem(keyname,score.toString());
+  return(score);
+}
+function process_result(cor) {
+  score=updateScore(cor);
+  doc_replace('#s#',lpad(score,6));
+}
+function get_timestamp() {
+  var now = new Date();
+  var res = now.toISOString().replace(/\D/g, "");;
+  return(res);
+}
+function prevent_form_resubmission() {
+  ts=get_timestamp();
+  document.replace('#NOW#',ts);
+}
+prevent_form_resubmission();
+res=prepare_task();
+inp=get_user_input();
+cor=evaluate_result(res[0],res[1],inp);
+process_result(cor);
+</script>
+</font>
+</body>
+</html>

--- a/test/ecmascript/document_replace.html
+++ b/test/ecmascript/document_replace.html
@@ -1,0 +1,8 @@
+<body>
+<html>
+<script>document.replace('#HERE#','ABC');</script>
+<pre>
+#HERE#
+</pre>
+</html>
+</body>

--- a/test/ecmascript/document_write.html
+++ b/test/ecmascript/document_write.html
@@ -1,11 +1,60 @@
 <html>
-<body>
-<a href="history.html">history.html</a><br/>
+<head>
+<title>
+-| 16 colors |-
+</title>
 <script type="text/javascript">
-document.writeln('<a href="ontest.html">Test</a><br/>');
-document.writeln('<a href="infinite2.html">infinite2.html</a><br/>');
-document.write(1,2,'3', '<br/>');
-</script>
-<a href="onload.html">onload.html</a><br/>
+document.writeln('<html><head><title>-| 16 colors |-</title></head><pre>');
+  var colors=[
+    "white",
+    "maroon",
+    "green",
+    "yellow",
+    "blue",
+    "magenta",
+    "cyan",
+    "white",
+    "grey",
+    "red",
+    "lime",
+    "olive",
+    "teal",
+    "purple",
+    "fuchsia",
+    "aqua",
+  ];
+
+  document.write('<table>');
+  colors.forEach(printstr);
+  document.write('</table>');
+  document.writeln('<br>');
+  colors.forEach(printstrln);
+
+  function lpad_str(str) {
+    if (str.length<=9) { str=(str+"    ").slice(-9); }
+    return str;
+  }
+  function lpad(number) {
+    if (number<=999) { number = ("00"+number).slice(-3); }
+    return number;
+  }
+  function printstr(item,index) {
+    if ((index)%4==0) { document.writeln("<tr>"); }
+    document.write('<td>');
+    document.write('<font color="'+item+'">'+lpad_str(item) +'</font> ');
+    document.write('<td>');
+    if ((index+1)%4==0) { document.writeln("</tr>"); }
+  }
+  function printstrln(item,index) {
+    document.writeln('<font color="'+item+'">'+lpad(index)+' This is '+item+'</font>');
+  }
+  document.writeln('');
+  document.writeln('<font color="yellow">This is true     : '+true+'</font>');
+  document.writeln('<font color="red">and this is false: '+false+'</font>');
+  document.writeln('<font color="yellow">',"That's it as ... ","1+1=",2,'</font>');
+  document.writeln('</pre></body></html>');
+ </script>
+</head>
+<body>
 </body>
 </html>


### PR DESCRIPTION
Hello rdk77,

this is pull request for following:
+ Fixed get property location in spidermonkey document.c
+ Added replace function in spidermonkey document.c
+ Fixed localstorage set item so numeric variable can be passed from js
+ Added function jshandle_value_to_char_string to util.h
+ Added emcascript_counter into document/document.h
+ Changed session/session.c and added rerender after document has been changed in js
+ Added tests for document.replace and document.write(ln)
+ Added helper function document replace of char*

The rerendering is really not 100% nice. But I didn't find any better solution than place it on the session
level. When I tried that from the actual document.replace it was probably called too often and had
some unexpected behavior.
There is a variable emcascript_counter that's activated only if document.writeln or document.replace
is called otherwise the rerender won't happend.
The other thing that this consists is the fix for numerical values from the actual js. SpiderMonkey 52 gives
variables with it's datatype and numbers has to be handled differently.
There is a helper function str_replace in document.c in spidermonkey. However probably it's not the nicest. 

Thas about it. Thank You very much