### PR TITLE
alert when moving to the next match of a failed search

### DIFF
--- a/src/viewer/text/search.c
+++ b/src/viewer/text/search.c
@@ -1323,6 +1323,7 @@ move_search_do(struct session *ses, struct document_view *doc_view, int directio
 		&doc_view->document->number_of_search_points, utf8);
 
 		if (error == FIND_ERROR_NOT_FOUND) {
+			print_find_error(ses, error);
 			return FRAME_EVENT_OK;
 		}
 	}


### PR DESCRIPTION
This was way easier than I thought. 

The problem was that pressing 'n' after a failed search shows nothing.
