### PR TITLE
optionally, going back from initial page closes tab or elinks

### DIFF
--- a/src/config/options.inc
+++ b/src/config/options.inc
@@ -1488,6 +1488,10 @@ static union option_info config_options_info[] = {
 		"Changes take effect at the next elinks restart.")),
 #endif
 
+	INIT_OPT_BOOL("ui", N_("Back to exit"),
+		"back_to_exit", 0, 0,
+		N_("Going back from initial page exits tab or elinks.")),
+
 	INIT_OPT_BOOL("ui", N_("Set window title"),
 		"window_title", 0, 1,
 		N_("Set the window title when running in a windowing "

--- a/src/session/history.c
+++ b/src/session/history.c
@@ -165,12 +165,13 @@ go_history(struct session *ses, struct location *loc)
 		 CACHE_MODE_ALWAYS, TASK_HISTORY, 0);
 }
 
-void
+int
 go_history_by_n(struct session *ses, int n)
 {
 	struct location *loc = cur_loc(ses);
 
-	if (!loc) return;
+	if (!loc)
+		return -1;
 
 	if (n > 0) {
 		while (n-- && list_has_next(ses->history.history, loc))
@@ -178,9 +179,12 @@ go_history_by_n(struct session *ses, int n)
 	} else {
 		while (n++ && list_has_prev(ses->history.history, loc))
 			loc = loc->prev;
+		if (n == 0 && ! list_has_prev(ses->history.history, loc))
+			return -1;
 	}
 
 	go_history(ses, loc);
+	return 0;
 }
 
 /** Go backward in the history.  See go_history() description regarding

--- a/src/session/history.h
+++ b/src/session/history.h
@@ -40,7 +40,7 @@ void go_history(struct session *ses, struct location *loc);
 
 /** Move back -@a n times if @a n is negative, forward @a n times if
  * positive. */
-void go_history_by_n(struct session *ses, int n);
+int go_history_by_n(struct session *ses, int n);
 
 void go_back(struct session *ses);
 void go_unback(struct session *ses);

--- a/src/viewer/action.c
+++ b/src/viewer/action.c
@@ -255,7 +255,9 @@ do_action(struct session *ses, enum main_action action_id, int verbose)
 		{
 			int count = int_max(1, eat_kbd_repeat_count(ses));
 
-			go_history_by_n(ses, -count);
+			if (go_history_by_n(ses, -count) &&
+			    get_opt_bool("ui.back_to_exit", NULL))
+				close_tab(term, ses);
 			break;
 		}
 		case ACT_MAIN_HISTORY_MOVE_FORWARD:


### PR DESCRIPTION
This commit introduces a new option ui.back_to_exit to close the current tab when going back from its initial page. It also closes elinks if it was the last tab.

This is what happens for example in some Android browser.

It may be useful on a PC is to make elinks work as an html file viewer, where another program calls elinks to show an html file, and the user expects to go back to that other program when going back from the initial page.