### PR TITLE
do not exit if SIGCHLD interrupts a read

### DIFF
--- a/config2.h.in
+++ b/config2.h.in
@@ -919,7 +919,7 @@
 #endif
 /* Enable GNU extensions on systems that have them.  */
 #ifndef _GNU_SOURCE
-# undef _GNU_SOURCE
+# define _GNU_SOURCE
 #endif
 /* Enable threading extensions on Solaris.  */
 #ifndef _POSIX_PTHREAD_SEMANTICS

--- a/src/osdep/unix/sysinfo.h
+++ b/src/osdep/unix/sysinfo.h
@@ -26,6 +26,9 @@ static inline int dir_sep(char x) { return x == '/'; }
 #include <pwd.h>
 #include <grp.h>
 
+#include <unistd.h>
+#include <errno.h>
+
 #endif
 
 #endif


### PR DESCRIPTION
Fixes #104.

The problem was with the SIGCHLD that naturally arrives when the child process (the uri passing program) ends. Normally, it interrupts the select in select_loop() in main/select.c, where it does not cause any problem. When the bug occurs, it instead interrupts the read() in in_kbd() in terminal/kbd.c. That causes a call to free_itrm(), which sets program.terminate to 1.

This commit fixes the problem by ignoring a -1 returned by read() if errno is EINTR. I am not sure whether this is appropriate behaviour.

Anyway, the uri passing programs should have a "block terminal" option like the external viewers. This way, elinks could stop reading keyboard during a call to an external program that reads input.