### PR TITLE
close stdin before calling a background program

### DIFF
--- a/src/osdep/osdep.h
+++ b/src/osdep/osdep.h
@@ -47,6 +47,7 @@ char *get_window_title(int codepage);
 void block_stdin(void);
 void unblock_stdin(void);
 int exe(char *);
+int exe_no_stdin(char *);
 int resize_window(int, int, int, int);
 int can_resize_window(int);
 int can_open_os_shell(int);

--- a/src/terminal/terminal.c
+++ b/src/terminal/terminal.c
@@ -226,11 +226,16 @@ void
 exec_thread(char *path, int p)
 {
 	int plen = strlen(path + 1) + 2;
+	pid_t pid;
+	int flags;
 
 #if defined(HAVE_SETPGID) && !defined(CONFIG_OS_BEOS) && !defined(HAVE_BEGINTHREAD)
 	if (path[0] == TERM_EXEC_NEWWIN) setpgid(0, 0);
 #endif
-	exe(path + 1);
+	if (path[0] == TERM_EXEC_BG)
+		exe_no_stdin(path + 1);
+	else
+		exe(path + 1);
 	if (path[plen]) unlink(path + plen);
 }
 


### PR DESCRIPTION
When elinks calls a program with TERM_EXEC_FG, it stops reading from stdin so that the program can do that. But with TERM_EXEC_BG, it does not. Both the program and elinks read from stdin. A keystroke may go to the first or to the second, unpredictably.