### PR TITLE
avoid use of tempnam

### DIFF
--- a/src/osdep/osdep.h
+++ b/src/osdep/osdep.h
@@ -52,6 +52,7 @@ int resize_window(int, int, int, int);
 int can_resize_window(int);
 int can_open_os_shell(int);
 void set_highpri(void);
+char *tempname(char *dir, char *pfx, char *suff);
 
 #ifdef USE_OPEN_PREALLOC
 int open_prealloc(char *, int, int, off_t);

--- a/src/session/download.h
+++ b/src/session/download.h
@@ -39,7 +39,12 @@ enum download_flags {
 	DOWNLOAD_RESUME_SELECTED = 2,
 
 	/** The file will be opened in an external handler.  */
-	DOWNLOAD_EXTERNAL = 4
+	DOWNLOAD_EXTERNAL = 4,
+
+	/** File overwriting is allowed. This is for temp names, since
+	 * the file is created by the same function that chooses its
+	 * name.  */
+	DOWNLOAD_OVERWRITE = 8
 };
 
 struct download {


### PR DESCRIPTION
I am in doubt whether I should duplicate ``name.source`` and call ``done_string(name)`` instead of just returning ``name.source`` in ``tempname()``.

This function creates the file empty and returns the name. This is unavoidable if using one of the suggested replacing functions, since they solve the race condition precisely by creating the file. The other changes are because of this, since the file by that name is now supposed to exist.

There is also a reference to the deprecated ``tempnam()`` in ``lua/core.c`` which is still to be replaced.
