### PR TITLE
MuJS javascript engine implementation

### DIFF
--- a/config2.h.in
+++ b/config2.h.in
@@ -64,6 +64,12 @@
 /* Define if you want: ECMAScript heartbeat support support */
 #mesondefine CONFIG_ECMASCRIPT_SMJS_HEARTBEAT
 
+/* Define if you want: SpiderMonkey document scripting support */
+#mesondefine CONFIG_ECMASCRIPT_MUJS
+
+/* Define if you want: ECMAScript heartbeat support support */
+#mesondefine CONFIG_ECMASCRIPT_MUJS_HEARTBEAT
+
 /* Define if you want: Exmode interface support */
 #mesondefine CONFIG_EXMODE
 
@@ -216,6 +222,9 @@
 
 /* Define if you want: SpiderMonkey support */
 #mesondefine CONFIG_SCRIPTING_SPIDERMONKEY
+
+/* Define if you want: MuJS support */
+#mesondefine CONFIG_SCRIPTING_MUJS
 
 /* Define if you want: Small binary support */
 #mesondefine CONFIG_SMALL

--- a/configure.ac
+++ b/configure.ac
@@ -753,6 +753,118 @@ if test "x$CONFIG_ECMASCRIPT_SMJS" = xyes ||
 fi
 
 # ===================================================================
+# Check for MuJS, optional even if installed.
+# ===================================================================
+
+# This option sets the $with_spidermonkey variable.
+AC_ARG_WITH([mujs],
+	[AS_HELP_STRING([--with-mujs],
+		[enable Mu Javascript engine])])
+
+# CONFIG_MUJS is initially blank.  We change it to "yes" or "no"
+# when we know for sure whether we're going to use SpiderMonkey or not.
+# (features.conf is not supposed to define it.)
+CONFIG_MUJS=
+CONFIG_XML=
+EL_SAVE_FLAGS
+
+case "$with_mujs" in
+	"" | no)
+		# The user specified --without-mujs.
+		# That overrides the other SpiderMonkey options.
+		AC_MSG_CHECKING([for MuJS])
+		AC_MSG_RESULT([disabled])
+		CONFIG_MUJS="no"
+		;;
+	yes)
+		;;
+	*)
+		AC_MSG_WARN([This version of ELinks does not support --with-mujs=DIRECTORY.])
+		;;
+esac
+
+for package in mujs; do
+	if test -n "$CONFIG_MUJS"; then
+		break
+	else
+		AC_MSG_CHECKING([for MuJS (mujs) in pkg-config $package])
+		if $PKG_CONFIG $pkg_config_static --cflags --libs $package > /dev/null 2>&AS_MESSAGE_LOG_FD; then
+			MUJS_LIBS="$($PKG_CONFIG $pkg_config_static --libs $package)"
+			MUJS_CFLAGS="$($PKG_CONFIG $pkg_config_static --cflags $package)"
+
+			LIBS="$MUJS_LIBS $LIBS_X"
+			CFLAGS="$CFLAGS_X $MUJS_CFLAGS"
+			CPPFLAGS="$CPPFLAGS_X $MUJS_CFLAGS"
+			AC_LANG_PUSH([C++])
+			AC_LINK_IFELSE(
+				[AC_LANG_PROGRAM([[
+					]], [])],
+				[CONFIG_MUJS=yes
+				 AC_MSG_RESULT([yes])],
+				[# Leave CONFIG_MUJS blank, to continue the search.
+				 AC_MSG_RESULT([found but unusable])])
+			AC_LANG_POP([C++])
+		else
+			AC_MSG_RESULT([no])
+		fi
+	fi
+done
+
+if test -z "$CONFIG_MUJS"; then
+	# Didn't find MuJS anywhere.
+	CONFIG_MUJS=no
+fi
+
+EL_RESTORE_FLAGS
+
+if test "x$CONFIG_MUJS" = xyes; then
+	CONFIG_XML=yes
+	EL_CONFIG(CONFIG_ECMASCRIPT_MUJS, [MuJS document scripting])
+else
+	CONFIG_ECMASCRIPT_MUJS=no
+fi
+
+EL_CONFIG_DEPENDS(CONFIG_ECMASCRIPT, [CONFIG_ECMASCRIPT_MUJS], [ECMAScript (JavaScript)])
+AC_SUBST(CONFIG_ECMASCRIPT_MUJS)
+
+if test "x$CONFIG_ECMASCRIPT_MUJS" = xyes &&
+   test "x$HAVE_JS_TRIGGEROPERATIONCALLBACK" = xyes &&
+   test "x$HAVE_SETITIMER" = xyes; then
+	EL_CONFIG(CONFIG_ECMASCRIPT_MUJS_HEARTBEAT, [ECMAScript heartbeat support])
+else
+	CONFIG_ECMASCRIPT_MUJS_HEARTBEAT=no
+fi
+AC_SUBST(CONFIG_ECMASCRIPT_MUJS_HEARTBEAT)
+
+
+# ===================================================================
+# Optional MuJS-based ECMAScript browser scripting
+# ===================================================================
+
+AC_ARG_ENABLE(sm-scripting,
+	      [  --disable-sm-scripting  disable ECMAScript browser scripting],
+	      [if test "$enableval" != no; then enableval="yes"; fi
+	       CONFIG_SCRIPTING_MUJS="$enableval";])
+
+if test "x$CONFIG_MUJS" = xyes &&
+   test "x$CONFIG_SCRIPTING_MUJS" = xyes; then
+	EL_CONFIG(CONFIG_SCRIPTING_MUJS, [SpiderMonkey])
+else
+	CONFIG_SCRIPTING_MUJS=no
+fi
+
+if test "x$CONFIG_ECMASCRIPT_MUJS" = xyes ||
+   test "x$CONFIG_SCRIPTING_MUJS" = xyes; then
+	LIBS="$LIBS $MUJS_LIBS"
+	EL_CONFIG(CONFIG_XML, [libxml++5.0])
+	AC_SUBST(MUJS_LIBS)
+	AC_SUBST(MUJS_CFLAGS)
+	AC_SUBST(CONFIG_MUJS)
+	AC_SUBST(CONFIG_XML)
+	CFLAGS="$CFLAGS -fpermissive $MUJS_CFLAGS"
+fi
+
+# ===================================================================
 # Check for Guile, optional even if installed.
 # ===================================================================
 
@@ -1031,13 +1143,14 @@ EL_CONFIG_SCRIPTING_RUBY
 # Setup global scripting
 # ===================================================================
 
-EL_CONFIG_DEPENDS(CONFIG_SCRIPTING, [CONFIG_SCRIPTING_GUILE CONFIG_SCRIPTING_LUA CONFIG_SCRIPTING_PERL CONFIG_SCRIPTING_PYTHON CONFIG_SCRIPTING_RUBY CONFIG_SCRIPTING_SPIDERMONKEY], [Browser scripting])
+EL_CONFIG_DEPENDS(CONFIG_SCRIPTING, [CONFIG_SCRIPTING_GUILE CONFIG_SCRIPTING_LUA CONFIG_SCRIPTING_PERL CONFIG_SCRIPTING_PYTHON CONFIG_SCRIPTING_RUBY CONFIG_SCRIPTING_SPIDERMONKEY CONFIG_SCRIPTING_MUJS], [Browser scripting])
 AC_SUBST(CONFIG_SCRIPTING_GUILE)
 AC_SUBST(CONFIG_SCRIPTING_LUA)
 AC_SUBST(CONFIG_SCRIPTING_PERL)
 AC_SUBST(CONFIG_SCRIPTING_PYTHON)
 AC_SUBST(CONFIG_SCRIPTING_RUBY)
 AC_SUBST(CONFIG_SCRIPTING_SPIDERMONKEY)
+AC_SUBST(CONFIG_SCRIPTING_MUJS)
 AC_SUBST(CONFIG_SCRIPTING)
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -771,7 +771,7 @@ EL_SAVE_FLAGS
 case "$with_mujs" in
 	"" | no)
 		# The user specified --without-mujs.
-		# That overrides the other SpiderMonkey options.
+		# That overrides the other MuJS options.
 		AC_MSG_CHECKING([for MuJS])
 		AC_MSG_RESULT([disabled])
 		CONFIG_MUJS="no"
@@ -841,14 +841,14 @@ AC_SUBST(CONFIG_ECMASCRIPT_MUJS_HEARTBEAT)
 # Optional MuJS-based ECMAScript browser scripting
 # ===================================================================
 
-AC_ARG_ENABLE(sm-scripting,
-	      [  --disable-sm-scripting  disable ECMAScript browser scripting],
+AC_ARG_ENABLE(mu-scripting,
+	      [  --disable-mu-scripting  disable ECMAScript browser scripting],
 	      [if test "$enableval" != no; then enableval="yes"; fi
 	       CONFIG_SCRIPTING_MUJS="$enableval";])
 
 if test "x$CONFIG_MUJS" = xyes &&
    test "x$CONFIG_SCRIPTING_MUJS" = xyes; then
-	EL_CONFIG(CONFIG_SCRIPTING_MUJS, [SpiderMonkey])
+	EL_CONFIG(CONFIG_SCRIPTING_MUJS, [MuJS])
 else
 	CONFIG_SCRIPTING_MUJS=no
 fi
@@ -856,11 +856,9 @@ fi
 if test "x$CONFIG_ECMASCRIPT_MUJS" = xyes ||
    test "x$CONFIG_SCRIPTING_MUJS" = xyes; then
 	LIBS="$LIBS $MUJS_LIBS"
-	EL_CONFIG(CONFIG_XML, [libxml++5.0])
 	AC_SUBST(MUJS_LIBS)
 	AC_SUBST(MUJS_CFLAGS)
 	AC_SUBST(CONFIG_MUJS)
-	AC_SUBST(CONFIG_XML)
 	CFLAGS="$CFLAGS -fpermissive $MUJS_CFLAGS"
 fi
 

--- a/src/ecmascript/ecmascript.h
+++ b/src/ecmascript/ecmascript.h
@@ -11,7 +11,13 @@
 
 #ifdef CONFIG_ECMASCRIPT
 
+#ifdef CONFIG_ECMASCRIPT_SMJS
 #include <jsapi.h>
+#endif
+
+#ifdef CONFIG_ECMASCRIPT_MUJS
+#include <mujs.h>
+#endif
 
 #include "main/module.h"
 #include "util/time.h"

--- a/src/ecmascript/mujs.h
+++ b/src/ecmascript/mujs.h
@@ -1,0 +1,27 @@
+#ifndef EL__ECMASCRIPT_MUJS_H
+#define EL__ECMASCRIPT_MUJS_H
+
+#include <musj.h>
+
+struct ecmascript_interpreter;
+struct form_view;
+struct form_state;
+struct string;
+
+void *mujs_get_interpreter(struct ecmascript_interpreter *interpreter);
+void mujs_put_interpreter(struct ecmascript_interpreter *interpreter);
+
+void mujs_detach_form_view(struct form_view *fv);
+void mujs_detach_form_state(struct form_state *fs);
+void mujs_moved_form_state(struct form_state *fs);
+
+void mujs_eval(struct ecmascript_interpreter *interpreter, struct string *code, struct string *ret);
+char *mujs_eval_stringback(struct ecmascript_interpreter *interpreter, struct string *code);
+int mujs_eval_boolback(struct ecmascript_interpreter *interpreter, struct string *code);
+
+void mujs_call_function(struct ecmascript_interpreter *interpreter);//, JS::HandleValue fun, struct string *ret);
+
+void free_document(void *doc);
+
+extern struct module mujs_module;
+#endif


### PR DESCRIPTION
Started some work on a way to implement MuJS into ELinks because it's more up-to-date than Mozilla's last Spidermonkey build in C. This may end up being a total bust, but I at least want to see how far I can take this.

One thing about the config, using `--with-spidermonkey` automatically enables sm scripting, but I couldn't find out exactly how to replicate that myself with mu scripting the few hours i poked at it. So for now one would have to explicitly specify both `--with-mujs` and `--enable-mu-scripting` to get that to work.

Also, to clarify a potential point of confusion the includes for <mujs.h> refer to the engine's installed library (/usr/include/mujs.h on linux) while "mujs.h" should refer to src/ecmascript/mujs.h. I might rename it later to avoid this confusion

I'm pretty open to changing just about everything so far, but as I said this is just a start and just about every change seems to be working as intended, but I'm not exactly sure if there are any conventions I should follow. I figure I'll just try to use the form of everything else that exists and try to have it connect seamlessly to mujs which should be easily installable from most repos instead of requiring shenanigans to have work.