### PR TITLE
[lua] expose reload() and goto_url() to lua api

### DIFF
--- a/src/scripting/lua/core.c
+++ b/src/scripting/lua/core.c
@@ -651,6 +651,27 @@ lua_error:
 
 /* End of set/get option */
 
+static int
+l_reload(LS)
+{
+	reload(lua_ses, CACHE_MODE_INCREMENT);
+	cls_redraw_all_terminals();
+	return 1;
+}
+
+static int
+l_goto_url(LS)
+{
+	if (lua_isstring(S, 1)) {
+		goto_url(lua_ses, (unsigned char *) lua_tostring(S, 1));
+		lua_pushnumber(S, 0);
+		return 1;
+	}
+
+	lua_pushnil(L);
+	return 1;
+}
+
 int
 eval_function(LS, int num_args, int num_results)
 {
@@ -711,6 +732,8 @@ init_lua(struct module *module)
 	lua_register(L, "xdialog", l_xdialog);
 	lua_register(L, "set_option", l_set_option);
 	lua_register(L, "get_option", l_get_option);
+	lua_register(L, "reload", l_reload);
+	lua_register(L, "goto_url", l_goto_url);
 
 	lua_pushstring(L, elinks_home ? elinks_home
 				      : (char *) CONFDIR);


### PR DESCRIPTION
Two api methods for lua scripting has been added.

`reload()` allows to refresh the document without triggering a new
html request. This commits expose that existing internal function to the
lua api.

One example where it is useful : making a lua hook that allows to edit a
local file we're browsing and see the change without having to perform a
full reload (thus losing the scrolling position). Or anything else that
allows to interactively modify the currently loaded document.

`goto_url()` allows to navigate to given url long after the page has been
loaded (so follow_url_hooks can't be used).

Example where it's useful : binding a key to load the latest archive.org
snapshot for current page (especially useful when using tor and being
constantly harassed by cloudflare).