### PR TITLE
po/sr.po: Update Serbian translation

### DIFF
--- a/po/sr.po
+++ b/po/sr.po
@@ -5,17 +5,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ELinks 0.10.6.CVS\n"
 "Report-Msgid-Bugs-To: elinks-users@linuxfromscratch.org\n"
-"POT-Creation-Date: 2021-12-02 17:03+0100\n"
-"PO-Revision-Date: 2021-11-25 15:38+0100\n"
+"POT-Creation-Date: 2021-11-22 22:12+0100\n"
+"PO-Revision-Date: 2021-12-12 23:02+0100\n"
 "Last-Translator: Strahinya Radich (Страхиња Радић) <contact@strahinja.org>\n"
 "Language-Team: Serbian <sr@li.org>\n"
 "Language: sr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
-"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
-"X-Generator: poe 1.3.9-1\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"X-Generator: poe 1.3.10-1\n"
 
 #: src/bfu/hierbox.c:332
 msgid "Close"
@@ -197,7 +196,7 @@ msgstr "Дигитални сат у статусној линији."
 
 #: src/bfu/leds.c:82 src/bfu/leds.c:102 src/bfu/leds.c:115
 #: src/config/options.inc:1377 src/config/options.inc:1384
-#: src/ecmascript/ecmascript.c:64 src/globhist/globhist.c:62
+#: src/ecmascript/ecmascript.c:59 src/globhist/globhist.c:62
 #: src/mime/backend/mailcap.c:93 src/mime/backend/mimetypes.c:52
 #: src/network/ssl/ssl.c:127 src/network/ssl/ssl.c:280
 msgid "Enable"
@@ -212,11 +211,8 @@ msgid "Format"
 msgstr "Формат"
 
 #: src/bfu/leds.c:88
-msgid ""
-"Format string for the digital clock. See the strftime(3) manpage for details."
-msgstr ""
-"Форматна ниска дигиталног сата. За више детаља, погледајте страницу упутства "
-"за strftime(3)."
+msgid "Format string for the digital clock. See the strftime(3) manpage for details."
+msgstr "Форматна ниска дигиталног сата. За више детаља, погледајте страницу упутства за strftime(3)."
 
 #: src/bfu/leds.c:95
 msgid "Show IP"
@@ -255,11 +251,8 @@ msgid "LEDs (visual indicators) options."
 msgstr "Опције диода (визуелних индикатора)"
 
 #: src/bfu/leds.c:117
-msgid ""
-"Enable LEDs. These visual indicators will inform you about various states."
-msgstr ""
-"Активирање диода. Ови визуелни индикатори ће вас обавештавати о разним "
-"стањима."
+msgid "Enable LEDs. These visual indicators will inform you about various states."
+msgstr "Активирање диода. Ови визуелни индикатори ће вас обавештавати о разним стањима."
 
 #. name:
 #: src/bfu/leds.c:465 src/bfu/leds.c:507
@@ -333,7 +326,7 @@ msgstr "Обележивачи"
 
 #: src/bookmarks/bookmarks.c:50
 msgid "Bookmark options."
-msgstr "Опције обележивача"
+msgstr "Опције обележивача."
 
 #: src/bookmarks/bookmarks.c:53 src/bookmarks/bookmarks.c:60
 msgid "File format"
@@ -364,15 +357,8 @@ msgid "Save folder state"
 msgstr "Чување стања фасцикле"
 
 #: src/bookmarks/bookmarks.c:70
-msgid ""
-"When saving bookmarks also store whether folders are expanded or not, so the "
-"look of the bookmark dialog is kept across ELinks sessions. If disabled all "
-"folders will appear unexpanded next time ELinks is run."
-msgstr ""
-"Приликом чувања обележивача, такође ће се чувати да ли су фасцикле "
-"проширене, чиме се изглед дијалога за обележиваче чува између различитих "
-"сесија ELinks-а. Уколико је ово деактивирано, при следећем покретању ELinks-"
-"а ће све фасцикле бити непроширене."
+msgid "When saving bookmarks also store whether folders are expanded or not, so the look of the bookmark dialog is kept across ELinks sessions. If disabled all folders will appear unexpanded next time ELinks is run."
+msgstr "Приликом чувања обележивача, такође ће се чувати да ли су фасцикле проширене, чиме се изглед дијалога за обележиваче чува између различитих сесија ELinks-а. Уколико је ово деактивирано, при следећем покретању ELinks-а ће све фасцикле бити непроширене."
 
 #: src/bookmarks/bookmarks.c:75
 msgid "Periodic snapshotting"
@@ -380,15 +366,11 @@ msgstr "Повремено чување снимка"
 
 #: src/bookmarks/bookmarks.c:77
 msgid ""
-"Automatically save a snapshot of all tabs periodically. This will "
-"periodically bookmark the tabs of each terminal in a separate folder for "
-"recovery after a crash.\n"
+"Automatically save a snapshot of all tabs periodically. This will periodically bookmark the tabs of each terminal in a separate folder for recovery after a crash.\n"
 "\n"
 "This feature requires bookmark support."
 msgstr ""
-"Повремено ће аутоматски чувати снимак свих језичака. Ово ће повремено "
-"забележити језичке сваког терминала у одвојену фасциклу ради опоравка после "
-"пада програма.\n"
+"Повремено ће аутоматски чувати снимак свих језичака. Ово ће повремено забележити језичке сваког терминала у одвојену фасциклу ради опоравка после пада програма.\n"
 "\n"
 "Ова могућност захтева подршку за обележиваче."
 
@@ -469,30 +451,16 @@ msgid "Cannot move folder inside itself"
 msgstr "Фасцикла се не може преместити у саму себе"
 
 #: src/bookmarks/dialogs.c:584
-msgid ""
-"You are trying to move the marked folder inside itself. To move the folder "
-"to a different location select the new location before pressing the Move "
-"button."
-msgstr ""
-"Покушавате да преместите означену фасциклу унутар ње саме. Да бисте фасциклу "
-"преместили на друго место, означите га пре активирања дугмета Премести."
+msgid "You are trying to move the marked folder inside itself. To move the folder to a different location select the new location before pressing the Move button."
+msgstr "Покушавате да преместите означену фасциклу унутар ње саме. Да бисте фасциклу преместили на друго место, означите га пре активирања дугмета Премести."
 
 #: src/bookmarks/dialogs.c:590
 msgid "Nothing to move"
 msgstr "Нема се шта премештати"
 
 #: src/bookmarks/dialogs.c:591
-msgid ""
-"To move bookmarks, first mark all the bookmarks (or folders) you want to "
-"move.  This can be done with the Insert key if you're using the default key-"
-"bindings.  An asterisk will appear near all marked bookmarks.  Now move to "
-"where you want to have the stuff moved to, and press the \"Move\" button."
-msgstr ""
-"Да бисте преместили обележиваче, прво означите све обележиваче (или "
-"фасцикле) које желите да преместите. Ово се може обавити тастером Insert ако "
-"користите подразумеване пречице. Поред сваког означеног обележивача ће се "
-"појавити звездица. Сада пређите тамо где желите да се све пребаци и "
-"притисните дугме „Премести“."
+msgid "To move bookmarks, first mark all the bookmarks (or folders) you want to move.  This can be done with the Insert key if you're using the default key-bindings.  An asterisk will appear near all marked bookmarks.  Now move to where you want to have the stuff moved to, and press the \"Move\" button."
+msgstr "Да бисте преместили обележиваче, прво означите све обележиваче (или фасцикле) које желите да преместите. Ово се може обавити тастером Insert ако користите подразумеване пречице. Поред сваког означеног обележивача ће се појавити звездица. Сада пређите тамо где желите да се све пребаци и притисните дугме „Премести“."
 
 #. accelerator_context(src/bookmarks/dialogs.c:bookmark_buttons, src/cache/dialogs.c:cache_buttons, src/globhist/dialogs.c:globhist_buttons, src/protocol/auth/dialogs.c:auth_buttons)
 #: src/bookmarks/dialogs.c:617 src/cache/dialogs.c:317
@@ -844,8 +812,7 @@ msgstr "Померање курсора налево"
 
 #: src/config/actions-edit.inc:33
 msgid "Toggle regex matching (type-ahead searching)"
-msgstr ""
-"Смењивање употребе регуларних израза (при претрази са постепеним уносом)"
+msgstr "Смењивање употребе регуларних израза (при претрази са постепеним уносом)"
 
 #: src/config/actions-edit.inc:34 src/config/actions-menu.inc:26
 msgid "Move cursor upwards"
@@ -1456,16 +1423,8 @@ msgid "Restrict to anonymous mode"
 msgstr "Ограничавање на анонимни режим"
 
 #: src/config/cmdline.c:792
-msgid ""
-"Restricts ELinks so it can run on an anonymous account. Local file browsing, "
-"downloads, and modification of options will be disabled. Execution of "
-"viewers is allowed, but entries in the association table can't be added or "
-"modified."
-msgstr ""
-"Ограничава ELinks тако да се он може покренути на анонимном налогу. Листање "
-"локалних датотека, преузимања и мењање опција ће бити деактивирано. "
-"Извршавање прегледача је дозвољено, али ставке у табели придруживања неће "
-"моћи да се додају или мењају."
+msgid "Restricts ELinks so it can run on an anonymous account. Local file browsing, downloads, and modification of options will be disabled. Execution of viewers is allowed, but entries in the association table can't be added or modified."
+msgstr "Ограничава ELinks тако да се он може покренути на анонимном налогу. Листање локалних датотека, преузимања и мењање опција ће бити деактивирано. Извршавање прегледача је дозвољено, али ставке у табели придруживања неће моћи да се додају или мењају."
 
 #: src/config/cmdline.c:798
 msgid "Autosubmit first form"
@@ -1480,14 +1439,8 @@ msgid "Clone internal session with given ID"
 msgstr "Клонирање интерне сесије са задатим ID-јем"
 
 #: src/config/cmdline.c:804
-msgid ""
-"Used internally when opening ELinks instances in new windows. The ID maps to "
-"information that will be used when creating the new instance. You don't want "
-"to use it."
-msgstr ""
-"Интерно се користи при отварању инстанци ELinks-а у новим прозорима. ID се "
-"односи на информацију која ће се користити при креирању нове инстанце. Ово "
-"вероватно нећете желети да користите."
+msgid "Used internally when opening ELinks instances in new windows. The ID maps to information that will be used when creating the new instance. You don't want to use it."
+msgstr "Интерно се користи при отварању инстанци ELinks-а у новим прозорима. ID се односи на информацију која ће се користити при креирању нове инстанце. Ово вероватно нећете желети да користите."
 
 #: src/config/cmdline.c:808 src/config/cmdline.c:810
 msgid "Use a specific local IP address"
@@ -1502,39 +1455,24 @@ msgid "Name of directory with configuration file"
 msgstr "Назив директоријума у коме је датотека са подешавањима"
 
 #: src/config/cmdline.c:820
-msgid ""
-"Path of the directory ELinks will read and write its config and runtime "
-"state files to instead of ~/.elinks. If the path does not begin with a '/' "
-"it is assumed to be relative to your HOME directory."
-msgstr ""
-"Путања директоријума из кога ће ELinks читати и у њега писати датотеке "
-"подешавања и извршног стања, уместо директоријума ~/.elinks. Уколико путања "
-"не почиње знаком „/“, онда се она посматра у односу на ваш HOME директоријум."
+msgid "Path of the directory ELinks will read and write its config and runtime state files to instead of ~/.elinks. If the path does not begin with a '/' it is assumed to be relative to your HOME directory."
+msgstr "Путања директоријума из кога ће ELinks читати и у њега писати датотеке подешавања и извршног стања, уместо директоријума ~/.elinks. Уколико путања не почиње знаком „/“, онда се она посматра у односу на ваш HOME директоријум."
 
 #: src/config/cmdline.c:825
 msgid "Print default configuration file to stdout"
 msgstr "Исписивање подразумеване датотеке са подешавањима на стандардни излаз"
 
 #: src/config/cmdline.c:827
-msgid ""
-"Print a configuration file with options set to the built-in defaults to "
-"stdout."
-msgstr ""
-"Исписује датотеку са подешавањима у којој све опције имају подразумеване "
-"вредности на стандардни излаз."
+msgid "Print a configuration file with options set to the built-in defaults to stdout."
+msgstr "Исписује датотеку са подешавањима у којој све опције имају подразумеване вредности на стандардни излаз."
 
 #: src/config/cmdline.c:832
 msgid "Name of configuration file"
 msgstr "Назив датотеке са подешавањима"
 
 #: src/config/cmdline.c:834
-msgid ""
-"Name of the configuration file that all configuration options will be read "
-"from and written to. It should be relative to config-dir."
-msgstr ""
-"Назив датотеке са подешавањима из које ће се читати и у коју ће се уписивати "
-"све опције подешавања. Требало би да буде релативна у односу на директоријум "
-"са подешавањима."
+msgid "Name of the configuration file that all configuration options will be read from and written to. It should be relative to config-dir."
+msgstr "Назив датотеке са подешавањима из које ће се читати и у коју ће се уписивати све опције подешавања. Требало би да буде релативна у односу на директоријум са подешавањима."
 
 #: src/config/cmdline.c:838
 msgid "Print help for configuration options"
@@ -1557,13 +1495,8 @@ msgid "Ignore user-defined keybindings"
 msgstr "Игнорише кориснички задате пречице"
 
 #: src/config/cmdline.c:849
-msgid ""
-"When set, all keybindings from configuration files will be ignored. It "
-"forces use of default keybindings and will reset user-defined ones on save."
-msgstr ""
-"Када је ово укључено, све пречице из датотека са подешавањима ће бити "
-"игнорисане. То намеће употребу подразумеваних пречица и поново ће их "
-"поставити на подразумеване вредности при чувању."
+msgid "When set, all keybindings from configuration files will be ignored. It forces use of default keybindings and will reset user-defined ones on save."
+msgstr "Када је ово укључено, све пречице из датотека са подешавањима ће бити игнорисане. То намеће употребу подразумеваних пречица и поново ће их поставити на подразумеване вредности при чувању."
 
 #: src/config/cmdline.c:853
 msgid "Print formatted versions of given URLs to stdout"
@@ -1571,8 +1504,7 @@ msgstr "Исписивање форматираних верзија задат�
 
 #: src/config/cmdline.c:855
 msgid "Print formatted plain-text versions of given URLs to stdout."
-msgstr ""
-"Исписује форматиране текстуалне верзије задатих УРЛ-ова на стандардни излаз."
+msgstr "Исписује форматиране текстуалне верзије задатих УРЛ-ова на стандардни излаз."
 
 #: src/config/cmdline.c:858
 msgid "Codepage to use with -dump"
@@ -1604,12 +1536,10 @@ msgstr "Обрада директиве датотеке са подешавањ
 
 #: src/config/cmdline.c:872
 msgid ""
-"Specify configuration file directives on the command-line which will be "
-"evaluated after all configuration files has been read. Example usage:\n"
+"Specify configuration file directives on the command-line which will be evaluated after all configuration files has been read. Example usage:\n"
 "\t-eval 'set protocol.file.allow_special_files = 1'"
 msgstr ""
-"Задавање директива датотеке са подешавањима које ће бити обрађене после "
-"читања свих датотека са подешавањима. Пример:\n"
+"Задавање директива датотеке са подешавањима које ће бити обрађене после читања свих датотека са подешавањима. Пример:\n"
 "\t-eval 'set protocol.file.allow_special_files = 1'"
 
 #. lynx compatibility
@@ -1618,14 +1548,8 @@ msgid "Interpret documents of unknown types as HTML"
 msgstr "Интерпретирање докумената непознатог типа као HTML"
 
 #: src/config/cmdline.c:880
-msgid ""
-"Makes ELinks assume documents of unknown types are HTML. Useful when using "
-"ELinks as an external viewer from MUAs. This is equivalent to -default-mime-"
-"type text/html."
-msgstr ""
-"Налаже ELinks-у да претпоставља да су документи непознатих типова HTML. "
-"Корисно када се ELinks користи као спољашњи прегледач из програма за пошту. "
-"Ово је еквивалентно -default-mime-type text/html."
+msgid "Makes ELinks assume documents of unknown types are HTML. Useful when using ELinks as an external viewer from MUAs. This is equivalent to -default-mime-type text/html."
+msgstr "Налаже ELinks-у да претпоставља да су документи непознатих типова HTML. Корисно када се ELinks користи као спољашњи прегледач из програма за пошту. Ово је еквивалентно -default-mime-type text/html."
 
 #: src/config/cmdline.c:890
 msgid "Print usage help and exit"
@@ -1640,14 +1564,8 @@ msgid "Only permit local connections"
 msgstr "Дозвољавају се само локална повезивања"
 
 #: src/config/cmdline.c:896
-msgid ""
-"Restricts ELinks to work offline and only connect to servers with local "
-"addresses (ie. 127.0.0.1). No connections to remote servers will be "
-"permitted."
-msgstr ""
-"Ограничава ELinks да ради ван мреже и да се само повезује са серверима који "
-"имају локалне адресе (нпр. 127.0.0.1). Повезивање са удаљеним серверима неће "
-"бити дозвољено."
+msgid "Restricts ELinks to work offline and only connect to servers with local addresses (ie. 127.0.0.1). No connections to remote servers will be permitted."
+msgstr "Ограничава ELinks да ради ван мреже и да се само повезује са серверима који имају локалне адресе (нпр. 127.0.0.1). Повезивање са удаљеним серверима неће бити дозвољено."
 
 #: src/config/cmdline.c:900
 msgid "Print detailed usage help and exit"
@@ -1663,38 +1581,23 @@ msgstr "Тражење адресе задатог хоста"
 
 #: src/config/cmdline.c:906
 msgid "Look up specified host and print all DNS resolved IP addresses."
-msgstr ""
-"Тражи адресу задатог хоста и исписује све IP адресе које су разрешене DNS-ом."
+msgstr "Тражи адресу задатог хоста и исписује све IP адресе које су разрешене DNS-ом."
 
 #: src/config/cmdline.c:909
 msgid "Run as separate instance"
 msgstr "Покретање засебне инстанце"
 
 #: src/config/cmdline.c:911
-msgid ""
-"Run ELinks as a separate instance instead of connecting to an existing "
-"instance. Note that normally no runtime state files (bookmarks, history, "
-"etc.) are written to the disk when this option is used. See also -touch-"
-"files."
-msgstr ""
-"Покретање ELinks-а као засебне инстанце уместо повезивања са постојећом "
-"инстанцом. Имајте у виду да се, када се употребљава ова опција, ниједна од "
-"датотека стања извршавања (обележивачи, историја, итд.) не записује на диск. "
-"Погледајте и -touch-files."
+msgid "Run ELinks as a separate instance instead of connecting to an existing instance. Note that normally no runtime state files (bookmarks, history, etc.) are written to the disk when this option is used. See also -touch-files."
+msgstr "Покретање ELinks-а као засебне инстанце уместо повезивања са постојећом инстанцом. Имајте у виду да се, када се употребљава ова опција, ниједна од датотека стања извршавања (обележивачи, историја, итд.) не записује на диск. Погледајте и -touch-files."
 
 #: src/config/cmdline.c:916
 msgid "Disable use of files in ~/.elinks"
 msgstr "Деактивирање коришћења датотека у директоријуму ~/.elinks"
 
 #: src/config/cmdline.c:918
-msgid ""
-"Disables creation and use of files in the user specific home configuration "
-"directory (~/.elinks). It forces default configuration values to be used and "
-"disables saving of runtime state files."
-msgstr ""
-"Деактивира креирање и употребу датотека у корисничком директоријуму са "
-"подешавањима (~/.elinks). Захтева да се користе подразумеване вредности "
-"подешавања и деактивира чување датотека стања извршавања."
+msgid "Disables creation and use of files in the user specific home configuration directory (~/.elinks). It forces default configuration values to be used and disables saving of runtime state files."
+msgstr "Деактивира креирање и употребу датотека у корисничком директоријуму са подешавањима (~/.elinks). Захтева да се користе подразумеване вредности подешавања и деактивира чување датотека стања извршавања."
 
 #: src/config/cmdline.c:923
 msgid "Disable libevent"
@@ -1738,11 +1641,7 @@ msgstr "Управљање већ покренутим ELinks-ом"
 
 #: src/config/cmdline.c:942
 msgid ""
-"Control a remote ELinks instance by passing commands to it. The option takes "
-"an additional argument containing the method which should be invoked and any "
-"parameters that should be passed to it. For ease of use, the additional "
-"method argument can be omitted in which case any URL arguments will be "
-"opened in new tabs in the remote instance.\n"
+"Control a remote ELinks instance by passing commands to it. The option takes an additional argument containing the method which should be invoked and any parameters that should be passed to it. For ease of use, the additional method argument can be omitted in which case any URL arguments will be opened in new tabs in the remote instance.\n"
 "\n"
 "Following is a list of the supported methods:\n"
 "\tping()                    : look for a remote instance\n"
@@ -1756,11 +1655,7 @@ msgid ""
 "\tsearch(string)            : search in the current tab\n"
 "\txfeDoCommand(openBrowser) : open new window"
 msgstr ""
-"Управља удаљеном инстанцом ELinks-а прослеђивањем наредби. Ова опција узима "
-"додатни аргумент који садржи метод који би требало покренути и параметре "
-"који би требало да се проследе. Ради лакше употребе, додатни аргумент метода "
-"се може изоставити, и тада ће сви аргументи УРЛ-а бити отворени у новим "
-"језичцима у удаљеној инстанци.\n"
+"Управља удаљеном инстанцом ELinks-а прослеђивањем наредби. Ова опција узима додатни аргумент који садржи метод који би требало покренути и параметре који би требало да се проследе. Ради лакше употребе, додатни аргумент метода се може изоставити, и тада ће сви аргументи УРЛ-а бити отворени у новим језичцима у удаљеној инстанци.\n"
 "\n"
 "Следи списак подржаних метода:\n"
 "\tping()                    : тражи удаљену инстанцу\n"
@@ -1780,35 +1675,15 @@ msgstr "Повезивање са сесијским прстеном корис
 
 #: src/config/cmdline.c:964
 msgid ""
-"ID of session ring this ELinks session should connect to. ELinks works in so-"
-"called session rings, whereby all instances of ELinks are interconnected and "
-"share state (cache, bookmarks, cookies, and so on). By default, all ELinks "
-"instances connect to session ring 0. You can change that behaviour with this "
-"switch and form as many session rings as you want. Obviously, if the session-"
-"ring with this number doesn't exist yet, it's created and this ELinks "
-"instance will become the master instance (that usually doesn't matter for "
-"you as a user much).\n"
+"ID of session ring this ELinks session should connect to. ELinks works in so-called session rings, whereby all instances of ELinks are interconnected and share state (cache, bookmarks, cookies, and so on). By default, all ELinks instances connect to session ring 0. You can change that behaviour with this switch and form as many session rings as you want. Obviously, if the session-ring with this number doesn't exist yet, it's created and this ELinks instance will become the master instance (that usually doesn't matter for you as a user much).\n"
 "\n"
-"Note that you usually don't want to use this unless you're a developer and "
-"you want to do some testing - if you want the ELinks instances each running "
-"standalone, rather use the -no-connect command-line option. Also note that "
-"normally no runtime state files are written to the disk when this option is "
-"used. See also -touch-files."
+"Note that you usually don't want to use this unless you're a developer and you want to do some testing - if you want the ELinks instances each running standalone, rather use the -no-connect command-line option. Also note that normally no runtime state files are written to the disk when this option is used. See also -touch-files."
 msgstr ""
 "ID сесијског прстена са којим би ова сесија ELinks-а требало да се\n"
 "повеже. ELinks ради у тзв. сесијским прстеновима, где се све\n"
-"инстанце ELinks-а међусобно повезују и деле стање (кеш, обележиваче, "
-"колачиће, итд.). Подразумевано се све инстанце ELinks-а повезују са "
-"сесијским прстеном број 0. Можете ово да промените овим прекидачем и "
-"направите онолико сесијских прстенова колико желите. Очигледно ће, у случају "
-"да сесијски прстен са тим бројем не постоји, он бити креиран, и та инстанца "
-"ELinks-а ће постати главна (то вама, као кориснику, не значи много).\n"
+"инстанце ELinks-а међусобно повезују и деле стање (кеш, обележиваче, колачиће, итд.). Подразумевано се све инстанце ELinks-а повезују са сесијским прстеном број 0. Можете ово да промените овим прекидачем и направите онолико сесијских прстенова колико желите. Очигледно ће, у случају да сесијски прстен са тим бројем не постоји, он бити креиран, и та инстанца ELinks-а ће постати главна (то вама, као кориснику, не значи много).\n"
 "\n"
-"Имајте у виду да вероватно нећете желети да ово користите, осим уколико сте "
-"програмер и желите да спроведете тестирање — уколико желите да се инстанце "
-"ELinks-а покрећу свака за себе, радије користите прекидач -no-connect. "
-"Такође, приметите да се ниједна датотека о стању извршавања не уписује на "
-"диск када се користи ова опција. Погледајте и -touch-files."
+"Имајте у виду да вероватно нећете желети да ово користите, осим уколико сте програмер и желите да спроведете тестирање — уколико желите да се инстанце ELinks-а покрећу свака за себе, радије користите прекидач -no-connect. Такође, приметите да се ниједна датотека о стању извршавања не уписује на диск када се користи ова опција. Погледајте и -touch-files."
 
 #: src/config/cmdline.c:982
 msgid "Print the source of given URLs to stdout"
@@ -1823,28 +1698,16 @@ msgid "Whether to use terminfo"
 msgstr "Да ли да се користи terminfo"
 
 #: src/config/cmdline.c:990
-msgid ""
-"When enabled, terminfo ncurses functions will be used instead of hardcoded "
-"sequences."
-msgstr ""
-"Када је укључено, terminfo ncurses функције ће се користити уместо "
-"предефинисаних секвенци."
+msgid "When enabled, terminfo ncurses functions will be used instead of hardcoded sequences."
+msgstr "Када је укључено, terminfo ncurses функције ће се користити уместо предефинисаних секвенци."
 
 #: src/config/cmdline.c:993
 msgid "Touch files in ~/.elinks when running with -no-connect/-session-ring"
-msgstr ""
-"Освежавање датотека у ~/.elinks када је задато -no-connect или -session-ring"
+msgstr "Освежавање датотека у ~/.elinks када је задато -no-connect или -session-ring"
 
 #: src/config/cmdline.c:995
-msgid ""
-"When enabled, runtime state files (bookmarks, history, etc.) are written to "
-"disk, even when -no-connect or -session-ring is used. The option has no "
-"effect if not used in conjunction with any of these options."
-msgstr ""
-"Када је ово активирано, датотеке стања извршавања (обележивачи, историја, "
-"итд.) ће се записивати на диск, чак и када је задато -no-connect или -"
-"session-ring. Ова опција нема утицаја ако се не користи заједно са неком од "
-"ових опција."
+msgid "When enabled, runtime state files (bookmarks, history, etc.) are written to disk, even when -no-connect or -session-ring is used. The option has no effect if not used in conjunction with any of these options."
+msgstr "Када је ово активирано, датотеке стања извршавања (обележивачи, историја, итд.) ће се записивати на диск, чак и када је задато -no-connect или -session-ring. Ова опција нема утицаја ако се не користи заједно са неком од ових опција."
 
 #: src/config/cmdline.c:1000
 msgid "Verbose level"
@@ -1852,14 +1715,12 @@ msgstr "Ниво брбљивости"
 
 #: src/config/cmdline.c:1002
 msgid ""
-"The verbose level controls what messages are shown at start up and while "
-"running:\n"
+"The verbose level controls what messages are shown at start up and while running:\n"
 "\t0 means only show serious errors\n"
 "\t1 means show serious errors and warnings\n"
 "\t2 means show all messages"
 msgstr ""
-"Ниво брбљивости контролише које поруке се приказују при покретању и током "
-"извршавања:\n"
+"Ниво брбљивости контролише које поруке се приказују при покретању и током извршавања:\n"
 "\t0 приказује само озбиљне грешке\n"
 "\t1 приказује озбиљне грешке и упозорења\n"
 "\t2 приказује све грешке"
@@ -2032,12 +1893,8 @@ msgid "Edit"
 msgstr "Уређивање"
 
 #: src/config/dialogs.c:391
-msgid ""
-"This option cannot be edited. This means that this is some special option "
-"like a folder - try to press a space in order to see its contents."
-msgstr ""
-"Ова опција не може да се уређује. То значи да је ово посебна опција, као "
-"фасцикла — покушајте да притиснете размакницу да бисте видели њен садржај."
+msgid "This option cannot be edited. This means that this is some special option like a folder - try to press a space in order to see its contents."
+msgstr "Ова опција не може да се уређује. То значи да је ово посебна опција, као фасцикла — покушајте да притиснете размакницу да бисте видели њен садржај."
 
 #: src/config/dialogs.c:431
 msgid ""
@@ -2128,28 +1985,18 @@ msgstr "Управљач пречица"
 
 #: src/config/home.c:128
 #, c-format
-msgid ""
-"Commandline options -config-dir set to %s, but could not create directory %s."
-msgstr ""
-"Опција командне линије -config-dir је подешена на %s, али се не може "
-"креирати директоријум %s."
+msgid "Commandline options -config-dir set to %s, but could not create directory %s."
+msgstr "Опција командне линије -config-dir је подешена на %s, али се не може креирати директоријум %s."
 
 #: src/config/home.c:133
 #, c-format
 msgid "ELINKS_CONFDIR set to %s, but could not create directory %s."
-msgstr ""
-"ELINKS_CONFDIR је подешено на %s, али се не може креирати директоријум %s."
+msgstr "ELINKS_CONFDIR је подешено на %s, али се не може креирати директоријум %s."
 
 #: src/config/home.c:156
 #, c-format
-msgid ""
-"Unable to find or create ELinks config directory. Please check if you have "
-"$HOME variable set correctly and if you have write permission to your home "
-"directory."
-msgstr ""
-"Не може се пронаћи или креирати ELinks-ов директоријум са подешавањима. "
-"Проверите да ли сте исправно подесили променљиву $HOME и да ли имате дозволу "
-"уписа у ваш кориснички директоријум."
+msgid "Unable to find or create ELinks config directory. Please check if you have $HOME variable set correctly and if you have write permission to your home directory."
+msgstr "Не може се пронаћи или креирати ELinks-ов директоријум са подешавањима. Проверите да ли сте исправно подесили променљиву $HOME и да ли имате дозволу уписа у ваш кориснички директоријум."
 
 #: src/config/kbdbind.c:60
 msgid "Main mapping"
@@ -2211,12 +2058,8 @@ msgid "Indentation"
 msgstr "Увлачење"
 
 #: src/config/options.inc:34
-msgid ""
-"Shift width of one indentation level in the configuration file. Zero means "
-"that no indentation is performed at all when saving the configuration."
-msgstr ""
-"Ширина једног нивоа увлачења у датотеци са подешавањима. Нула значи да се "
-"увлачење при чувању подешавања уопште не примењује."
+msgid "Shift width of one indentation level in the configuration file. Zero means that no indentation is performed at all when saving the configuration."
+msgstr "Ширина једног нивоа увлачења у датотеци са подешавањима. Нула значи да се увлачење при чувању подешавања уопште не примењује."
 
 #: src/config/options.inc:38
 msgid "Saving style"
@@ -2247,42 +2090,24 @@ msgid "Comments localization"
 msgstr "Локализација коментара"
 
 #: src/config/options.inc:52
-msgid ""
-"If set to 1, comments in the configuration file will be translated to the "
-"language used by UI. Note that if you have different language set in "
-"different terminals, the language used in the configuration file MAY be the "
-"same as on the terminal where you saved the file, but it should be generally "
-"considered unpredictable."
-msgstr ""
-"Уколико се ово постави на 1, коментари у датотеци са подешавањима ће бити "
-"преведени на језик на ком је интерфејс. Приметите да, уколико сте на разним "
-"терминалима подесили разне језике, језик који ће бити коришћен у датотеци са "
-"подешавањима МОЖЕ да буде исти као на терминалу са кога сте сачували "
-"датотеку, али уопштено ово треба сматрати непредвидивим."
+msgid "If set to 1, comments in the configuration file will be translated to the language used by UI. Note that if you have different language set in different terminals, the language used in the configuration file MAY be the same as on the terminal where you saved the file, but it should be generally considered unpredictable."
+msgstr "Уколико се ово постави на 1, коментари у датотеци са подешавањима ће бити преведени на језик на ком је интерфејс. Приметите да, уколико сте на разним терминалима подесили разне језике, језик који ће бити коришћен у датотеци са подешавањима МОЖЕ да буде исти као на терминалу са кога сте сачували датотеку, али уопштено ово треба сматрати непредвидивим."
 
 #: src/config/options.inc:60
 msgid "Saving style warnings"
 msgstr "Упозорења начина чувања"
 
 #: src/config/options.inc:62
-msgid ""
-"This is internal option used when displaying a warning about obsolete config."
-"saving_style. You shouldn't touch it."
-msgstr ""
-"Ово је интерна опција која се користи при приказивању упозорења о застарелој "
-"вредности опције config.saving_style. Не би требало да је мењате."
+msgid "This is internal option used when displaying a warning about obsolete config.saving_style. You shouldn't touch it."
+msgstr "Ово је интерна опција која се користи при приказивању упозорења о застарелој вредности опције config.saving_style. Не би требало да је мењате."
 
 #: src/config/options.inc:66
 msgid "Show template"
 msgstr "Приказивање шаблона"
 
 #: src/config/options.inc:68
-msgid ""
-"Show template options in autocreated trees in the options manager and save "
-"them to the configuration file."
-msgstr ""
-"Приказивање опција шаблона у аутоматски креираним стаблима у управљачу "
-"опција и чување у датотеку са подешавањима."
+msgid "Show template options in autocreated trees in the options manager and save them to the configuration file."
+msgstr "Приказивање опција шаблона у аутоматски креираним стаблима у управљачу опција и чување у датотеку са подешавањима."
 
 #. Keep options in alphabetical order.
 #: src/config/options.inc:74 src/dialogs/info.c:181
@@ -2323,9 +2148,7 @@ msgstr "Поновни покушаји повезивања"
 
 #: src/config/options.inc:94
 msgid "Number of tries to establish a connection. Zero means try forever."
-msgstr ""
-"Број покушаја да се успостави повезивање. Нула значи да се покушава "
-"бесконачно много пута."
+msgstr "Број покушаја да се успостави повезивање. Нула значи да се покушава бесконачно много пута."
 
 #: src/config/options.inc:97 src/network/state.c:53
 msgid "Receive timeout"
@@ -2341,32 +2164,23 @@ msgstr "Покушај повезивања преко IPv4"
 
 #: src/config/options.inc:104
 msgid ""
-"Whether to try to connect to a host over IPv4. Note that if connection."
-"try_ipv6 is enabled too, it takes precedence. And better do not touch this "
-"at all unless you are sure what are you doing.\n"
+"Whether to try to connect to a host over IPv4. Note that if connection.try_ipv6 is enabled too, it takes precedence. And better do not touch this at all unless you are sure what are you doing.\n"
 "\n"
-"Note that you can also force a given protocol to be used on a per-connection "
-"basis by using a URL in the style of e.g. http4://elinks.cz/."
+"Note that you can also force a given protocol to be used on a per-connection basis by using a URL in the style of e.g. http4://elinks.cz/."
 msgstr ""
-"Да ли да се покуша повезивање са хостом преко IPv4. Приметите да опција "
-"connection.try_ipv6 има предност уколико је и она активирана. Боље је да ово "
-"не мењате, осим уколико знате шта радите.\n"
+"Да ли да се покуша повезивање са хостом преко IPv4. Приметите да опција connection.try_ipv6 има предност уколико је и она активирана. Боље је да ово не мењате, осим уколико знате шта радите.\n"
 "\n"
-"Приметите да преко УРЛ-а као што је, нпр. http4://elinks.cz/ можете и да "
-"захтевате да се задати протокол користи на нивоу појединачних повезивања."
+"Приметите да преко УРЛ-а као што је, нпр. http4://elinks.cz/ можете и да захтевате да се задати протокол користи на нивоу појединачних повезивања."
 
 #: src/config/options.inc:115
 msgid ""
 "Whether to try to connect to a host over IPv4. Do not touch this option.\n"
 "\n"
-"Note that you can also force a given protocol to be used on a per-connection "
-"basis by using a URL in the style of e.g. http4://elinks.cz/."
+"Note that you can also force a given protocol to be used on a per-connection basis by using a URL in the style of e.g. http4://elinks.cz/."
 msgstr ""
-"Да ли да се покуша повезивање са хостом преко IPv4. Боље је да ово не "
-"мењате.\n"
+"Да ли да се покуша повезивање са хостом преко IPv4. Боље је да ово не мењате.\n"
 "\n"
-"Приметите да преко УРЛ-а као што је, нпр. http4://elinks.cz/ можете и да "
-"захтевате да се задати протокол користи на нивоу појединачних повезивања."
+"Приметите да преко УРЛ-а као што је, нпр. http4://elinks.cz/ можете и да захтевате да се задати протокол користи на нивоу појединачних повезивања."
 
 #: src/config/options.inc:124
 msgid "Try IPv6 when connecting"
@@ -2376,13 +2190,11 @@ msgstr "Покушај повезивања преко IPv6"
 msgid ""
 "Whether to try to connect to a host over IPv6.\n"
 "\n"
-"Note that you can also force a given protocol to be used on a per-connection "
-"basis by using a URL in the style of e.g. http6://elinks.cz/."
+"Note that you can also force a given protocol to be used on a per-connection basis by using a URL in the style of e.g. http6://elinks.cz/."
 msgstr ""
 "Да ли да се покуша повезивање са хостом преко IPv6.\n"
 "\n"
-"Приметите да преко УРЛ-а као што је, нпр. http6://elinks.cz/ можете да "
-"захтевате да се задани протокол користи на нивоу појединачних повезивања."
+"Приметите да преко УРЛ-а као што је, нпр. http6://elinks.cz/ можете да захтевате да се задани протокол користи на нивоу појединачних повезивања."
 
 #: src/config/options.inc:133
 msgid "Timeout for non-restartable connections"
@@ -2390,8 +2202,7 @@ msgstr "Дозвољено време за повезивања која се н
 
 #: src/config/options.inc:135
 msgid "Timeout for non-restartable connections (in seconds)."
-msgstr ""
-"Дозвољено време за повезивања која се не могу поново покренути (у секундима)."
+msgstr "Дозвољено време за повезивања која се не могу поново покренути (у секундима)."
 
 #. Keep options in alphabetical order.
 #: src/config/options.inc:141
@@ -2415,27 +2226,16 @@ msgid "Access keys"
 msgstr "Приступни тастери"
 
 #: src/config/options.inc:152
-msgid ""
-"Options for handling of link access keys. An HTML document can use the "
-"ACCESSKEY attribute to assign an access key to an element. When an access "
-"key is pressed, the corresponding element will be given focus."
-msgstr ""
-"Опције руковања тастерима за приступ везама. У HTML документу се може "
-"користити атрибут ACCESSKEY да се елементу додели приступни тастер. Када се "
-"приступни тастер притисне, одговарајући елемент ће бити фокусиран."
+msgid "Options for handling of link access keys. An HTML document can use the ACCESSKEY attribute to assign an access key to an element. When an access key is pressed, the corresponding element will be given focus."
+msgstr "Опције руковања тастерима за приступ везама. У HTML документу се може користити атрибут ACCESSKEY да се елементу додели приступни тастер. Када се приступни тастер притисне, одговарајући елемент ће бити фокусиран."
 
 #: src/config/options.inc:157
 msgid "Automatic links following"
 msgstr "Аутоматско праћење веза"
 
 #: src/config/options.inc:159
-msgid ""
-"Automatically follow a link or submit a form if appropriate accesskey is "
-"pressed - this is the standard behaviour, but it's considered dangerous."
-msgstr ""
-"Аутоматски ће се пратити веза или предати образац када се притисне "
-"одговарајући приступни тастер. Ово је стандардно понашање, али се оно сматра "
-"опасним."
+msgid "Automatically follow a link or submit a form if appropriate accesskey is pressed - this is the standard behaviour, but it's considered dangerous."
+msgstr "Аутоматски ће се пратити веза или предати образац када се притисне одговарајући приступни тастер. Ово је стандардно понашање, али се оно сматра опасним."
 
 #: src/config/options.inc:163
 msgid "Display access key in link info"
@@ -2479,11 +2279,8 @@ msgid "Submit form automatically"
 msgstr "Аутоматско предавање образаца"
 
 #: src/config/options.inc:183
-msgid ""
-"Automagically submit a form when enter is pressed with a text field selected."
-msgstr ""
-"Аутомагично ће се предати образац када се притисне тастер enter у "
-"текстуалном пољу."
+msgid "Automagically submit a form when enter is pressed with a text field selected."
+msgstr "Аутомагично ће се предати образац када се притисне тастер enter у текстуалном пољу."
 
 #: src/config/options.inc:186
 msgid "Confirm submission"
@@ -2499,27 +2296,15 @@ msgstr "Подразумевана величина поља за унос у о
 
 #: src/config/options.inc:192
 msgid "Default form input size if none is specified."
-msgstr ""
-"Подразумевана величина поља за унос у обрасцима уколико она није задата."
+msgstr "Подразумевана величина поља за унос у обрасцима уколико она није задата."
 
 #: src/config/options.inc:194
 msgid "Insert mode"
 msgstr "Режим уметања"
 
 #: src/config/options.inc:196
-msgid ""
-"The setting for this option affects how key presses are handled when one "
-"selects a text-input form-field. When enabled, one must explicitly 'enter' a "
-"selected text-field to edit it; this prevents text fields from capturing key "
-"presses, such as presses of a scroll key, when it is inadvertently selected. "
-"When disabled, key presses are always inserted into a selected text field."
-msgstr ""
-"Постављање ове опције утиче на то како се рукује притисцима на тастере када "
-"је изабрано поље за унос текста у обрасцу. ко је ово активирано, мора се "
-"експлицитно ући у изабрано поље за унос текста да би се у њега уносио текст. "
-"Ово спречава да поље за унос хвата притиске на тастере, као што су тастери "
-"за клизање, када се оно случајно изабере. Ако је ово деактивирано, притисци "
-"на тастере се увек умећу у изабрано поље за унос."
+msgid "The setting for this option affects how key presses are handled when one selects a text-input form-field. When enabled, one must explicitly 'enter' a selected text-field to edit it; this prevents text fields from capturing key presses, such as presses of a scroll key, when it is inadvertently selected. When disabled, key presses are always inserted into a selected text field."
+msgstr "Постављање ове опције утиче на то како се рукује притисцима на тастере када је изабрано поље за унос текста у обрасцу. ко је ово активирано, мора се експлицитно ући у изабрано поље за унос текста да би се у њега уносио текст. Ово спречава да поље за унос хвата притиске на тастере, као што су тастери за клизање, када се оно случајно изабере. Ако је ово деактивирано, притисци на тастере се увек умећу у изабрано поље за унос."
 
 #: src/config/options.inc:204
 msgid "External editor"
@@ -2527,18 +2312,13 @@ msgstr "Спољашњи уређивач"
 
 #: src/config/options.inc:206
 msgid ""
-"Path to the executable that ELinks should launch when the user requests to "
-"edit a textarea with an external editor.\n"
+"Path to the executable that ELinks should launch when the user requests to edit a textarea with an external editor.\n"
 "\n"
-"If this is blank, ELinks will use the value of the environmental variable "
-"$EDITOR. If $EDITOR is empty or not set, ELinks will then default to \"vi\"."
+"If this is blank, ELinks will use the value of the environmental variable $EDITOR. If $EDITOR is empty or not set, ELinks will then default to \"vi\"."
 msgstr ""
-"Путања ка извршној датотеци коју би ELinks требало да покрене када корисник "
-"захтева да уређује текстуално поље спољашњим уређивачем.\n"
+"Путања ка извршној датотеци коју би ELinks требало да покрене када корисник захтева да уређује текстуално поље спољашњим уређивачем.\n"
 "\n"
-"Ако је ово празно, ELinks ће користити вредност променљиве окружења $EDITOR. "
-"Уколико је та променљива празна или није постављена, ELinks ће онда "
-"подразумевати програм „vi“."
+"Ако је ово празно, ELinks ће користити вредност променљиве окружења $EDITOR. Уколико је та променљива празна или није постављена, ELinks ће онда подразумевати програм „vi“."
 
 #: src/config/options.inc:214
 msgid "Images"
@@ -2643,26 +2423,16 @@ msgid "Display links to images w/o alt"
 msgstr "Приказивање веза ка сликама без атрибута alt"
 
 #: src/config/options.inc:266
-msgid ""
-"Display links to images without an alt attribute. If this option is off, "
-"these images are completely invisible."
-msgstr ""
-"Приказиваће се везе ка сликама без атрибута alt. Уколико је ова опција "
-"искључена, такве слике су потпуно невидљиве."
+msgid "Display links to images without an alt attribute. If this option is off, these images are completely invisible."
+msgstr "Приказиваће се везе ка сликама без атрибута alt. Уколико је ова опција искључена, такве слике су потпуно невидљиве."
 
 #: src/config/options.inc:269
 msgid "Display links to images"
 msgstr "Приказивање веза ка сликама"
 
 #: src/config/options.inc:271
-msgid ""
-"Display links to any images in the document, regardless of them having an "
-"alt attribute or not. If this option is off, the alt attribute contents is "
-"shown, but as normal text, not selectable as a link."
-msgstr ""
-"Приказиваће се везе ка свим сликама у документу, без обзира на то имају ли "
-"атрибут alt или не. Уколико је ова опција искључена, приказиваће се садржај "
-"атрибута alt, али као обичан текст, па он неће моћи да се изабере као веза."
+msgid "Display links to any images in the document, regardless of them having an alt attribute or not. If this option is off, the alt attribute contents is shown, but as normal text, not selectable as a link."
+msgstr "Приказиваће се везе ка свим сликама у документу, без обзира на то имају ли атрибут alt или не. Уколико је ова опција искључена, приказиваће се садржај атрибута alt, али као обичан текст, па он неће моћи да се изабере као веза."
 
 #: src/config/options.inc:277
 msgid "Links"
@@ -2741,12 +2511,8 @@ msgid "Enable color"
 msgstr "Активирање боја"
 
 #: src/config/options.inc:311
-msgid ""
-"Enable use of the active link background and text color settings instead of "
-"the link colors from the document."
-msgstr ""
-"Активирање употребе поставке позадине и боје текста текуће везе уместо боја "
-"веза из документа."
+msgid "Enable use of the active link background and text color settings instead of the link colors from the document."
+msgstr "Активирање употребе поставке позадине и боје текста текуће везе уместо боја веза из документа."
 
 #: src/config/options.inc:314
 msgid "Bold"
@@ -2762,8 +2528,7 @@ msgstr "Инверзија боја"
 
 #: src/config/options.inc:320
 msgid "Invert the fore- and background color so the link stands out."
-msgstr ""
-"Боје позадине и текста ће бити инвертоване како би везе биле уочљивије."
+msgstr "Боје позадине и текста ће бити инвертоване како би везе биле уочљивије."
 
 #: src/config/options.inc:323 src/config/options.inc:1072
 #: src/dialogs/options.c:235
@@ -2780,9 +2545,7 @@ msgstr "Истицање директоријума"
 
 #: src/config/options.inc:330
 msgid "Highlight links to directories in FTP and local directory listing."
-msgstr ""
-"Истицаће се везе ка директоријумима у листинзима FTP-а и локалних "
-"директоријума."
+msgstr "Истицаће се везе ка директоријумима у листинзима FTP-а и локалних директоријума."
 
 #: src/config/options.inc:333
 msgid "Number links"
@@ -2798,9 +2561,7 @@ msgstr "Приказивање дијалога за прелазак на бр�
 
 #: src/config/options.inc:339
 msgid "Display go to link number dialog, when links numbering is enabled."
-msgstr ""
-"Приказивање дијалога за прелазак на број везе када је активирано нумерисање "
-"веза."
+msgstr "Приказивање дијалога за прелазак на број везе када је активирано нумерисање веза."
 
 #: src/config/options.inc:341
 msgid "Handling of target=_blank"
@@ -2826,26 +2587,16 @@ msgid "Use tabindex"
 msgstr "Употреба „tabindex“-а"
 
 #: src/config/options.inc:358
-msgid ""
-"Whether to navigate links using tabindex specified ordering. The TABINDEX "
-"attribute in HTML elements specifies the order in which links should receive "
-"focus when using the keyboard to navigate the document."
-msgstr ""
-"Да ли ће се пратити везе уз помоћ редоследа који је задат у атрибуту "
-"„tabindex“. Тај атрибут у елементима HTML-а задаје редослед по коме би везе "
-"требало да буду фокусиране када се за кретање по документу користи тастатура."
+msgid "Whether to navigate links using tabindex specified ordering. The TABINDEX attribute in HTML elements specifies the order in which links should receive focus when using the keyboard to navigate the document."
+msgstr "Да ли ће се пратити везе уз помоћ редоследа који је задат у атрибуту „tabindex“. Тај атрибут у елементима HTML-а задаје редослед по коме би везе требало да буду фокусиране када се за кретање по документу користи тастатура."
 
 #: src/config/options.inc:363
 msgid "Specify link label key"
 msgstr "Задавање тастера пречице везе"
 
 #: src/config/options.inc:365
-msgid ""
-"Default is 0123456789, which is standard numeric labeling. Ascii based "
-"strings like gfdsahjkl;trewqyuiopvcxznm can also be used."
-msgstr ""
-"Подразумева се 0123456789, што је стандардно нумеричко озчачавање. Могу се "
-"користити и ascii ниске, као што је gfdsahjkl;trewqyuiopvcxznm."
+msgid "Default is 0123456789, which is standard numeric labeling. Ascii based strings like gfdsahjkl;trewqyuiopvcxznm can also be used."
+msgstr "Подразумева се 0123456789, што је стандардно нумеричко озчачавање. Могу се користити и ascii ниске, као што је gfdsahjkl;trewqyuiopvcxznm."
 
 #: src/config/options.inc:369
 msgid "Missing fragment reporting"
@@ -2853,8 +2604,7 @@ msgstr "Пријављивање недостајућих делова"
 
 #: src/config/options.inc:371
 msgid "Open a message box when document has no tag with given id."
-msgstr ""
-"Отвараће се прозор са поруком када документ нема ознаку са задатим ID-јем."
+msgstr "Отвараће се прозор са поруком када документ нема ознаку са задатим ID-јем."
 
 #: src/config/options.inc:374
 msgid "Number keys select links"
@@ -2862,14 +2612,12 @@ msgstr "Бирање веза тастерима са бројевима"
 
 #: src/config/options.inc:376
 msgid ""
-"Number keys select links rather than specify command prefixes. This is a "
-"tristate:\n"
+"Number keys select links rather than specify command prefixes. This is a tristate:\n"
 "0 means never\n"
 "1 means if document.browse.links.numbering = 1\n"
 "2 means always"
 msgstr ""
-"Тастери са бројевима бирају везе, а не задају префиксе наредбама. Ово је "
-"троизбор:\n"
+"Тастери са бројевима бирају везе, а не задају префиксе наредбама. Ово је троизбор:\n"
 "0 никад\n"
 "1 само уколико је document.browse.links.numbering = 1\n"
 "2 увек"
@@ -2879,14 +2627,8 @@ msgid "Warn about maliciously crafted URIs"
 msgstr "Упозоравати о злонамерним УРИ-јевима"
 
 #: src/config/options.inc:384
-msgid ""
-"When following a link the user ID part of the URI is checked and if a "
-"maliciously crafted URI is detected a warning dialog will ask before "
-"following the link."
-msgstr ""
-"Када се прати веза, провераваће се део УРИ-ја са корисничким ID-јем и "
-"уколико се препозна злонамеран УРИ, дијалог упозорења ће тражити потврду пре "
-"праћења везе."
+msgid "When following a link the user ID part of the URI is checked and if a maliciously crafted URI is detected a warning dialog will ask before following the link."
+msgstr "Када се прати веза, провераваће се део УРИ-ја са корисничким ID-јем и уколико се препозна злонамеран УРИ, дијалог упозорења ће тражити потврду пре праћења везе."
 
 #. TODO - this is somehow implemented by ff, but disabled
 #. * for now as it doesn't work.
@@ -2896,11 +2638,8 @@ msgstr "Кружно кретање кроз везе"
 
 #. 0
 #: src/config/options.inc:392
-msgid ""
-"When pressing 'down' on the last link, jump to the first one, and vice versa."
-msgstr ""
-"Када се на последњој вези притисне стрелица надоле, скочиће се на прву, и "
-"обрнуто."
+msgid "When pressing 'down' on the last link, jump to the first one, and vice versa."
+msgstr "Када се на последњој вези притисне стрелица надоле, скочиће се на прву, и обрнуто."
 
 #: src/config/options.inc:396
 msgid "Scrolling"
@@ -2915,60 +2654,40 @@ msgid "Horizontal step"
 msgstr "Хоризонтални корак"
 
 #: src/config/options.inc:402
-msgid ""
-"Number of columns to scroll when a key bound to scroll-left or scroll-right "
-"is pressed and no prefix was given."
-msgstr ""
-"Број колона за који се скролује када се притисне тастер додељен акцији "
-"scroll-left или scroll-right а не зада префикс."
+msgid "Number of columns to scroll when a key bound to scroll-left or scroll-right is pressed and no prefix was given."
+msgstr "Број колона за који се скролује када се притисне тастер додељен акцији scroll-left или scroll-right а не зада префикс."
 
 #: src/config/options.inc:406
 msgid "Extended horizontal scrolling"
 msgstr "Проширено хоризонтално скроловање"
 
 #: src/config/options.inc:408
-msgid ""
-"Whether to allow horizontal scrolling when the document does not extend off "
-"the screen. Useful for copy/paste operations."
-msgstr ""
-"Да ли ће се дозволити хоризонтално скроловање када ширина документа не "
-"прелази ширину екрана. Корисно за операције копирај-и-залепи."
+msgid "Whether to allow horizontal scrolling when the document does not extend off the screen. Useful for copy/paste operations."
+msgstr "Да ли ће се дозволити хоризонтално скроловање када ширина документа не прелази ширину екрана. Корисно за операције копирај-и-залепи."
 
 #: src/config/options.inc:412
 msgid "Margin"
 msgstr "Маргина"
 
 #: src/config/options.inc:414
-msgid ""
-"Size of the virtual margin - when you click inside of that margin, document "
-"scrolls in that direction."
-msgstr ""
-"Величина виртуелне маргине — када притиснете дугме миша унутар те маргине, "
-"документ ће скроловати у том правцу."
+msgid "Size of the virtual margin - when you click inside of that margin, document scrolls in that direction."
+msgstr "Величина виртуелне маргине — када притиснете дугме миша унутар те маргине, документ ће скроловати у том правцу."
 
 #: src/config/options.inc:417
 msgid "Vertical step"
 msgstr "Вертикални корак"
 
 #: src/config/options.inc:419
-msgid ""
-"Number of lines to scroll when a key bound to scroll-up or scroll-down is "
-"pressed and no prefix was given."
-msgstr ""
-"Број редова за скроловање када се притисне тастер додељен акцији scroll-up "
-"или scroll-down а не зада префикс."
+msgid "Number of lines to scroll when a key bound to scroll-up or scroll-down is pressed and no prefix was given."
+msgstr "Број редова за скроловање када се притисне тастер додељен акцији scroll-up или scroll-down а не зада префикс."
 
 #: src/config/options.inc:422
 msgid "Vertical overlap"
 msgstr "Вертикално преклапање"
 
 #: src/config/options.inc:424
-msgid ""
-"Number of overlapping lines between the new page displayed and the previous "
-"one when scrolling one page up or down."
-msgstr ""
-"Број преклапајућих редова између нове и претходне приказане странице када се "
-"скролује једну страницу навише или наниже."
+msgid "Number of overlapping lines between the new page displayed and the previous one when scrolling one page up or down."
+msgstr "Број преклапајућих редова између нове и претходне приказане странице када се скролује једну страницу навише или наниже."
 
 #: src/config/options.inc:428
 msgid "Searching"
@@ -2991,24 +2710,16 @@ msgid "Case sensitivity"
 msgstr "Разликовање великих и малих слова"
 
 #: src/config/options.inc:438
-msgid ""
-"Whether the search should match the document text while maintaining case "
-"sensitivity."
-msgstr ""
-"Да ли би требало да се претражује текст документа без обраћања пажње на "
-"велика или мала слова."
+msgid "Whether the search should match the document text while maintaining case sensitivity."
+msgstr "Да ли би требало да се претражује текст документа без обраћања пажње на велика или мала слова."
 
 #: src/config/options.inc:441
 msgid "Ignore history in typeahead"
 msgstr "Игнорисање историје код постепене претраге"
 
 #: src/config/options.inc:443
-msgid ""
-"Whether to ignore searching history in the typeahead mode. Cursor up and "
-"cursor down will only show latest search results."
-msgstr ""
-"Да ли да се игнорише историја претраге у режиму постепеног уноса. Стрелица "
-"нагоре и стрелица надоле ће приказати само најновије резултате претраге."
+msgid "Whether to ignore searching history in the typeahead mode. Cursor up and cursor down will only show latest search results."
+msgstr "Да ли да се игнорише историја претраге у режиму постепеног уноса. Стрелица нагоре и стрелица надоле ће приказати само најновије резултате претраге."
 
 #: src/config/options.inc:447
 msgid "Regular expressions"
@@ -3031,24 +2742,16 @@ msgid "Reset searching on new pages"
 msgstr "Поновно постављање претраге на новим страницама"
 
 #: src/config/options.inc:457
-msgid ""
-"Whether to clear search, when visiting new pages, or going back in history. "
-"If you set it to 0, you can search once and see results on every page."
-msgstr ""
-"Да ли да се чисти претрага приликом посете новим страницама или кретања "
-"уназад кроз историју. Ако подесите на 0, можете претражити једном и видети "
-"резултате на свакој страници."
+msgid "Whether to clear search, when visiting new pages, or going back in history. If you set it to 0, you can search once and see results on every page."
+msgstr "Да ли да се чисти претрага приликом посете новим страницама или кретања уназад кроз историју. Ако подесите на 0, можете претражити једном и видети резултате на свакој страници."
 
 #: src/config/options.inc:461
 msgid "Show search hit top or bottom dialogs"
 msgstr "Приказивање дијалога када се достигне врх или дно странице"
 
 #: src/config/options.inc:463
-msgid ""
-"Whether to show a dialog when the search hits the top or bottom of the "
-"document."
-msgstr ""
-"Да ли ће приказивати дијалог када претрага достигне врх или дно документа."
+msgid "Whether to show a dialog when the search hits the top or bottom of the document."
+msgstr "Да ли ће приказивати дијалог када претрага достигне врх или дно документа."
 
 #: src/config/options.inc:466
 msgid "Wraparound"
@@ -3056,8 +2759,7 @@ msgstr "Кружна претрага"
 
 #: src/config/options.inc:468
 msgid "Wrap around when searching. Currently only used for typeahead."
-msgstr ""
-"Кружиће при претрази. Тренутно се користи само за претрагу постепеним уносом."
+msgstr "Кружиће при претрази. Тренутно се користи само за претрагу постепеним уносом."
 
 #: src/config/options.inc:471
 msgid "Show not found"
@@ -3081,9 +2783,7 @@ msgstr "Претрага постепеним уносом"
 
 #: src/config/options.inc:480
 msgid ""
-"Start typeahead searching when an unbound key is pressed without any "
-"modifiers. Note that most keys have default bindings, so this feature will "
-"not be useful unless you unbind them.\n"
+"Start typeahead searching when an unbound key is pressed without any modifiers. Note that most keys have default bindings, so this feature will not be useful unless you unbind them.\n"
 "\n"
 "0 disables this feature; typeahead searching will only be\n"
 "  used when you press a key bound to search-typeahead or\n"
@@ -3092,10 +2792,7 @@ msgid ""
 "2 automatically starts typeahead searching thru all document\n"
 "  text"
 msgstr ""
-"Почиње претрагу постепеним уносом када се без икаквих помоћних тастера "
-"притисне тастер коме није додељена акција. Приметите да су већини тастера "
-"додељене подразумеване акције, па вам ова могућност неће бити од користи "
-"осим уколико поништите те доделе.\n"
+"Почиње претрагу постепеним уносом када се без икаквих помоћних тастера притисне тастер коме није додељена акција. Приметите да су већини тастера додељене подразумеване акције, па вам ова могућност неће бити од користи осим уколико поништите те доделе.\n"
 "\n"
 "0 деактивира ову могућност; претрага постепеним уносом ће\n"
 "  бити коришћена само када притиснете тастер који је\n"
@@ -3118,11 +2815,8 @@ msgid "Preferred document width"
 msgstr "Преферирана ширина документа"
 
 #: src/config/options.inc:499
-msgid ""
-"Try to fit the document within this width.  If set to zero,use screen width."
-msgstr ""
-"Покушаће се смештање документа унутар ове ширине. Ако се постави на нулу, "
-"користиће се ширина екрана."
+msgid "Try to fit the document within this width.  If set to zero,use screen width."
+msgstr "Покушаће се смештање документа унутар ове ширине. Ако се постави на нулу, користиће се ширина екрана."
 
 #: src/config/options.inc:502
 msgid "Whether to use preferred document width"
@@ -3143,35 +2837,18 @@ msgstr "meta refresh у документу"
 
 #: src/config/options.inc:509
 msgid ""
-"Automatically follow document-specified refresh directives ('<meta> refresh' "
-"tags). Web-page authors use these to instruct the browser to reload a "
-"document at a given interval or to load another page. Regardless of the "
-"value the refresh URI is accessible as a link.\n"
+"Automatically follow document-specified refresh directives ('<meta> refresh' tags). Web-page authors use these to instruct the browser to reload a document at a given interval or to load another page. Regardless of the value the refresh URI is accessible as a link.\n"
 "\n"
-"Use the document.browse.minimum_refresh_time to control the minimum number "
-"of seconds a refresh will wait."
-msgstr ""
-"Аутоматско поштовање директиве за освежавање (ознаке „<meta> refresh“). "
-"Аутори веб страница их користе да наложе читачу да поново учита документ по "
-"истеку задатог интервала или да учита неку другу страницу. Без обзира на "
-"вредност ове опције, УРИ за освежавање је доступан као веза. Користите "
-"опцију document.browse.minimum_refresh_time за задавање минималног броја "
-"секунди чекања до освежавања."
+"Use the document.browse.minimum_refresh_time to control the minimum number of seconds a refresh will wait."
+msgstr "Аутоматско поштовање директиве за освежавање (ознаке „<meta> refresh“). Аутори веб страница их користе да наложе читачу да поново учита документ по истеку задатог интервала или да учита неку другу страницу. Без обзира на вредност ове опције, УРИ за освежавање је доступан као веза. Користите опцију document.browse.minimum_refresh_time за задавање минималног броја секунди чекања до освежавања."
 
 #: src/config/options.inc:518
 msgid "Document meta refresh minimum time"
 msgstr "Минимално време чекања за meta refresh"
 
 #: src/config/options.inc:520
-msgid ""
-"The minimum number of milliseconds that should pass before refreshing. If "
-"set to zero the document refresh time is used unchanged. It can fix going "
-"back in history for some sites that use refreshing with zero values."
-msgstr ""
-"Минимални број милисекунди који би требало да прође пре освежавања. Уколико "
-"се постави на нулу, задато време до освежавања документа се не мења. Ово "
-"може да проузрокује кретање уназад кроз историју код неких докумената који "
-"користе нулто време до освежавања."
+msgid "The minimum number of milliseconds that should pass before refreshing. If set to zero the document refresh time is used unchanged. It can fix going back in history for some sites that use refreshing with zero values."
+msgstr "Минимални број милисекунди који би требало да прође пре освежавања. Уколико се постави на нулу, задато време до освежавања документа се не мења. Ово може да проузрокује кретање уназад кроз историју код неких докумената који користе нулто време до освежавања."
 
 #: src/config/options.inc:525
 msgid "Show meta refresh link"
@@ -3204,49 +2881,20 @@ msgstr "Кеширање података о преусмеравањима"
 
 #: src/config/options.inc:543
 msgid ""
-"Cache even redirects sent by server (usually thru HTTP by a 302 HTTP code "
-"and a Location header). This was the original behaviour for quite some time, "
-"but it causes problems in a situation very common to various web login "
-"systems - frequently, when accessing a certain location, they will redirect "
-"you to a login page if they don't receive an auth cookie, the login page "
-"then gives you the cookie and redirects you back to the original page, but "
-"there you have already cached redirect back to the login page! If this "
-"option has value of 0, this malfunction is fixed, but occasionally you may "
-"get superfluous (depends on how you take it ;-) requests to the server. If "
-"this option has value of 1, experienced users can still workaround it by "
-"clever combination of usage of reload, jumping around in session history and "
-"hitting ctrl+enter.\n"
+"Cache even redirects sent by server (usually thru HTTP by a 302 HTTP code and a Location header). This was the original behaviour for quite some time, but it causes problems in a situation very common to various web login systems - frequently, when accessing a certain location, they will redirect you to a login page if they don't receive an auth cookie, the login page then gives you the cookie and redirects you back to the original page, but there you have already cached redirect back to the login page! If this option has value of 0, this malfunction is fixed, but occasionally you may get superfluous (depends on how you take it ;-) requests to the server. If this option has value of 1, experienced users can still workaround it by clever combination of usage of reload, jumping around in session history and hitting ctrl+enter.\n"
 "\n"
-"Note that this option is checked when retrieving the information from cache, "
-"not when saving it to cache - thus if you enable it, even previous redirects "
-"will be taken from cache instead of asking the server."
+"Note that this option is checked when retrieving the information from cache, not when saving it to cache - thus if you enable it, even previous redirects will be taken from cache instead of asking the server."
 msgstr ""
-"Кеширање чак и преусмеравања која шаље сервер (обично преко HTTP-а и кода "
-"302 са заглављем „Location“). Ово је дуже време било подразумевано понашање, "
-"али оно проузрокује проблеме у ситуацијама које су веома честе у разним "
-"системима за пријављивање преко веба — често, када се приступа одређеном "
-"месту, они ће вас преусмерити на страницу за пријављивање уколико не добију "
-"колачић за потврду исправности, која ће вам онда дати колачић, и преусмерити "
-"вас на првобитну страницу, али тамо већ имате преусмеравање из оставе према "
-"страници за пријављивање! Уколико се ово постави на 0, онда ће овакво "
-"понашање бити спречено, али повремено можете добити сувишне (зависно од "
-"вашег схватања ;-) захтеве серверу. Уколико се ово постави на 1, искусни "
-"корисници ипак могу да ово реше паметном комбинацијом поновног учитавања, "
-"кретања по историји сесије и притискања „ctrl+enter“.\n"
+"Кеширање чак и преусмеравања која шаље сервер (обично преко HTTP-а и кода 302 са заглављем „Location“). Ово је дуже време било подразумевано понашање, али оно проузрокује проблеме у ситуацијама које су веома честе у разним системима за пријављивање преко веба — често, када се приступа одређеном месту, они ће вас преусмерити на страницу за пријављивање уколико не добију колачић за потврду исправности, која ће вам онда дати колачић, и преусмерити вас на првобитну страницу, али тамо већ имате преусмеравање из оставе према страници за пријављивање! Уколико се ово постави на 0, онда ће овакво понашање бити спречено, али повремено можете добити сувишне (зависно од вашег схватања ;-) захтеве серверу. Уколико се ово постави на 1, искусни корисници ипак могу да ово реше паметном комбинацијом поновног учитавања, кретања по историји сесије и притискања „ctrl+enter“.\n"
 "\n"
-"Имајте у виду да се вредност ове опције проверава приликом добављања "
-"података из кеша, а не приликом чувања у кеш, тако да уколико желите да га "
-"активирате, чак ће и претходна преусмеравања бити узета из кеша уместо са "
-"сервера."
+"Имајте у виду да се вредност ове опције проверава приликом добављања података из кеша, а не приликом чувања у кеш, тако да уколико желите да га активирате, чак ће и претходна преусмеравања бити узета из кеша уместо са сервера."
 
 #: src/config/options.inc:564
 msgid "Ignore cache-control info from server"
 msgstr "Занемаривање података о управљању кешом од сервера"
 
 #: src/config/options.inc:566
-msgid ""
-"Ignore Cache-Control and Pragma server headers. When set, the document is "
-"cached even with 'Cache-Control: no-cache'."
+msgid "Ignore Cache-Control and Pragma server headers. When set, the document is cached even with 'Cache-Control: no-cache'."
 msgstr ""
 "Занемаривање серверских заглавља „Cache-Control“ и\n"
 "„Pragma“. Када је постављено, документ ће бити смештен у\n"
@@ -3266,33 +2914,13 @@ msgstr "Број"
 
 #: src/config/options.inc:576
 msgid ""
-"Number of cached formatted pages. Do not get too generous here, 'formatted' "
-"means that all the accompanying structures are kept in memory so that you "
-"get the cached document immediately, but these structures may take a lot - "
-"2x the size of the HTML source is probably not unusual, but it can be even "
-"more if the document consists of a lot of short lines (padded right, if "
-"possible) and links and not much other markup. So if you set this to 256 and "
-"then you don't like your ELinks eating 90M, don't come complaining to "
-"us. ;-)\n"
+"Number of cached formatted pages. Do not get too generous here, 'formatted' means that all the accompanying structures are kept in memory so that you get the cached document immediately, but these structures may take a lot - 2x the size of the HTML source is probably not unusual, but it can be even more if the document consists of a lot of short lines (padded right, if possible) and links and not much other markup. So if you set this to 256 and then you don't like your ELinks eating 90M, don't come complaining to us. ;-)\n"
 "\n"
-"Also note that the format cache itself is not counted to the memory cache "
-"size, but the HTML source of the formatted documents is always cached, even "
-"if it is over the memory cache size threshold. (Then of course no other "
-"documents can be cached.)"
+"Also note that the format cache itself is not counted to the memory cache size, but the HTML source of the formatted documents is always cached, even if it is over the memory cache size threshold. (Then of course no other documents can be cached.)"
 msgstr ""
-"Број форматираних страница у кешу. Овде немојте бити превише великодушни, "
-"јер „форматирано“ значи да се све пратеће структуре чувају у меморији тако "
-"да можете одмах да добијете документ из кеша, али те структуре заузимају "
-"много простора — неретко 2x више од величине изворног кода странице у HTML-"
-"у, а ово може да буде и више уколико се документ састоји од кратких редова "
-"текста (по могућству, поравнатих удесно) и веза и једва нешто додатних "
-"ознака. Зато, ако подесите ово на 256 и онда вам се не свиди што вам је "
-"ELinks појео 90Мб, немојте нам се жалити. ;-)\n"
+"Број форматираних страница у кешу. Овде немојте бити превише великодушни, јер „форматирано“ значи да се све пратеће структуре чувају у меморији тако да можете одмах да добијете документ из кеша, али те структуре заузимају много простора — неретко 2x више од величине изворног кода странице у HTML-у, а ово може да буде и више уколико се документ састоји од кратких редова текста (по могућству, поравнатих удесно) и веза и једва нешто додатних ознака. Зато, ако подесите ово на 256 и онда вам се не свиди што вам је ELinks појео 90Мб, немојте нам се жалити. ;-)\n"
 "\n"
-"Такође, приметите да се, сам за себе, кеш формата не рачуна у величину "
-"меморијског кеша, али се изворни код форматираних докумената у HTML-у увек "
-"смешта у кеш, чак и када прелази границу меморијског кеша. (Тада, наравно, "
-"ниједан други документ не може бити кеширан.)"
+"Такође, приметите да се, сам за себе, кеш формата не рачуна у величину меморијског кеша, али се изворни код форматираних докумената у HTML-у увек смешта у кеш, чак и када прелази границу меморијског кеша. (Тада, наравно, ниједан други документ не може бити кеширан.)"
 
 #. FIXME: Write more.
 #: src/config/options.inc:594
@@ -3301,17 +2929,10 @@ msgstr "Интервал поновне валидације"
 
 #: src/config/options.inc:596
 msgid ""
-"Period in seconds that a cache entry is considered to be up-to-date. When a "
-"document is loaded and this interval has elapsed since the document was "
-"initially loaded or most recently revalidated with the server, the server "
-"will be checked in case there is a more up-to-date version of the document.\n"
+"Period in seconds that a cache entry is considered to be up-to-date. When a document is loaded and this interval has elapsed since the document was initially loaded or most recently revalidated with the server, the server will be checked in case there is a more up-to-date version of the document.\n"
 "\n"
 "A value of -1 disables automatic revalidation."
-msgstr ""
-"Интервал у секундима током ког се ставка кеша сматра ажурном. Када се "
-"документ учита, а овај интервал је истекао од првог учитавања документа или "
-"најсвежије валидације на серверу, провериће се да ли постоји свежија верзија "
-"документа на серверу."
+msgstr "Интервал у секундима током ког се ставка кеша сматра ажурном. Када се документ учита, а овај интервал је истекао од првог учитавања документа или најсвежије валидације на серверу, провериће се да ли постоји свежија верзија документа на серверу."
 
 #: src/config/options.inc:605 src/dialogs/info.c:200
 msgid "Memory cache"
@@ -3338,12 +2959,8 @@ msgid "Default codepage"
 msgstr "Подразумевана кодна страна"
 
 #: src/config/options.inc:621
-msgid ""
-"Default document codepage. 'System' stands for a codepage determined by a "
-"selected locale."
-msgstr ""
-"Подразумевана кодна страна документа. „System“ означава одређивање кодне "
-"странице из изабраног локала."
+msgid "Default document codepage. 'System' stands for a codepage determined by a selected locale."
+msgstr "Подразумевана кодна страна документа. „System“ означава одређивање кодне странице из изабраног локала."
 
 #: src/config/options.inc:624
 msgid "Ignore charset info from server"
@@ -3412,12 +3029,8 @@ msgid "Use link number color"
 msgstr "Користити боју броја везе"
 
 #: src/config/options.inc:667
-msgid ""
-"Whether to use link number color even when colors specified by the document "
-"are used."
-msgstr ""
-"Да ли да се користи боја броја везе, чак и када се користе боје задате у "
-"документу."
+msgid "Whether to use link number color even when colors specified by the document are used."
+msgstr "Да ли да се користи боја броја везе, чак и када се користе боје задате у документу."
 
 #: src/config/options.inc:670
 msgid "Link number color"
@@ -3432,16 +3045,8 @@ msgid "Increase contrast"
 msgstr "Повећање контраста"
 
 #: src/config/options.inc:680
-msgid ""
-"Increase the contrast between the foreground and background colors to ensure "
-"readability. For example it disallows dark colors on a black background. "
-"Note, this is different from ensuring the contrast with the ensure_contrast "
-"option."
-msgstr ""
-"Постављање ове опције на 0 ће увећати контраст између боја текста и позадине "
-"како би се осигурала читљивост. На пример, то спречава тамне боје на црној "
-"позадини. Имајте у виду да је ово другачије од осигуравања контраста преко "
-"опције ensure_contrast."
+msgid "Increase the contrast between the foreground and background colors to ensure readability. For example it disallows dark colors on a black background. Note, this is different from ensuring the contrast with the ensure_contrast option."
+msgstr "Постављање ове опције на 0 ће увећати контраст између боја текста и позадине како би се осигурала читљивост. На пример, то спречава тамне боје на црној позадини. Имајте у виду да је ово другачије од осигуравања контраста преко опције ensure_contrast."
 
 #: src/config/options.inc:686
 msgid "Ensure contrast"
@@ -3500,12 +3105,8 @@ msgid "Set original time"
 msgstr "Постављање изворног времена"
 
 #: src/config/options.inc:718
-msgid ""
-"Set the timestamp of each downloaded file to the timestamp stored on the "
-"server."
-msgstr ""
-"Постављање времена сваке преузете датотеке на време датотеке ускладиштене на "
-"серверу."
+msgid "Set the timestamp of each downloaded file to the timestamp stored on the server."
+msgstr "Постављање времена сваке преузете датотеке на време датотеке ускладиштене на серверу."
 
 #. Does automatic resuming make sense as an option?
 #: src/config/options.inc:722
@@ -3555,12 +3156,8 @@ msgid "Codepage"
 msgstr "Кодна страна"
 
 #: src/config/options.inc:743
-msgid ""
-"Codepage used in dump output. 'System' stands for a codepage determined by a "
-"selected locale."
-msgstr ""
-"Кодна страна која се користи у истоварном излазу. „System“ значи да ће кодна "
-"страна бити одређена изабраним локалитетом."
+msgid "Codepage used in dump output. 'System' stands for a codepage determined by a selected locale."
+msgstr "Кодна страна која се користи у истоварном излазу. „System“ значи да ће кодна страна бити одређена изабраним локалитетом."
 
 #: src/config/options.inc:746 src/config/options.inc:1034
 msgid "Color mode"
@@ -3575,9 +3172,7 @@ msgstr "Режим боја"
 msgid ""
 "Color mode for dumps.\n"
 "\n"
-"Some modes may have been disabled at compile time. The Setup -> Terminal "
-"options dialog lists the modes supported by this executable. If you select "
-"an unsupported mode, ELinks uses 16 colors.\n"
+"Some modes may have been disabled at compile time. The Setup -> Terminal options dialog lists the modes supported by this executable. If you select an unsupported mode, ELinks uses 16 colors.\n"
 "\n"
 "The color modes are:\n"
 "-1 is standard dump mode\n"
@@ -3589,9 +3184,7 @@ msgid ""
 msgstr ""
 "Режим боја за истовар.\n"
 "\n"
-"Неки режими су можда онемогућени приликом компајлирања. Дијалог Подешавања -"
-"> Опције терминала приказује режиме које подржава ова извршна датотека. "
-"Уколико изаберете неподржани режим, ELinks користи 16 боја.\n"
+"Неки режими су можда онемогућени приликом компајлирања. Дијалог Подешавања -> Опције терминала приказује режиме које подржава ова извршна датотека. Уколико изаберете неподржани режим, ELinks користи 16 боја.\n"
 "\n"
 "Режими боја су следећи:\n"
 "-1 стандардни режим истовара\n"
@@ -3629,9 +3222,7 @@ msgstr "Упућивања"
 
 #: src/config/options.inc:782
 msgid "Whether to print references (URIs) of document links in dump output."
-msgstr ""
-"Да ли ће се штампати упућивања (УРИ-ји) на везе ка документима у истоварном "
-"излазу."
+msgstr "Да ли ће се штампати упућивања (УРИ-ји) на везе ка документима у истоварном излазу."
 
 #: src/config/options.inc:785
 msgid "Separator"
@@ -3686,12 +3277,8 @@ msgid "Display iframes"
 msgstr "Приказивање iframe-ова"
 
 #: src/config/options.inc:814
-msgid ""
-"Display iframes. Iframe code is not finished. This option is disabled by "
-"default."
-msgstr ""
-"Приказивање iframe-ова. Код за iframe-ове није довршен. Ова опција је "
-"подразумевано деактивирана."
+msgid "Display iframes. Iframe code is not finished. This option is disabled by default."
+msgstr "Приказивање iframe-ова. Код за iframe-ове није довршен. Ова опција је подразумевано деактивирана."
 
 #: src/config/options.inc:816
 msgid "Display tables"
@@ -3752,15 +3339,8 @@ msgid "Wrap non breaking space"
 msgstr "Прелом непреломивог размака"
 
 #: src/config/options.inc:844
-msgid ""
-"If set do not honour non breaking space (the nbsp entity) but allows one to "
-"wrap the text. This can help keeping the width of documents down so no "
-"horizontal scrolling is needed."
-msgstr ""
-"Уколико је ово постављено, неће се поштовати непреломиви размак (ентитет "
-"„nbsp“), већ ће бити дозвољен прелом текста. Ово може да помогне да ширина "
-"документа не пређе одређену границу, тако да се избегне хоризонтално "
-"скроловање."
+msgid "If set do not honour non breaking space (the nbsp entity) but allows one to wrap the text. This can help keeping the width of documents down so no horizontal scrolling is needed."
+msgstr "Уколико је ово постављено, неће се поштовати непреломиви размак (ентитет „nbsp“), већ ће бити дозвољен прелом текста. Ово може да помогне да ширина документа не пређе одређену границу, тако да се избегне хоризонтално скроловање."
 
 #: src/config/options.inc:849
 msgid "Plain rendering"
@@ -3784,20 +3364,15 @@ msgstr "Компримовање празних редова"
 
 #: src/config/options.inc:859
 msgid "Compress successive empty lines to only one in displayed text."
-msgstr ""
-"Компримовање узастопних празних редова на један ред у приказаном тексту."
+msgstr "Компримовање узастопних празних редова на један ред у приказаном тексту."
 
 #: src/config/options.inc:862
 msgid "Fixup frame borders of tables"
 msgstr "Поправљање ивица оквира табела"
 
 #: src/config/options.inc:864
-msgid ""
-"Change ascii border characters to frame borders. Usage example: mysql --"
-"pager=elinks"
-msgstr ""
-"Промена ascii знакова за ивице на ивице оквира. Пример употребе: mysql --"
-"pager=elinks"
+msgid "Change ascii border characters to frame borders. Usage example: mysql --pager=elinks"
+msgstr "Промена ascii знакова за ивице на ивице оквира. Пример употребе: mysql --pager=elinks"
 
 #: src/config/options.inc:867
 msgid "URI passing"
@@ -3805,30 +3380,17 @@ msgstr "Прослеђивање УРИ-ја"
 
 #: src/config/options.inc:869
 msgid ""
-"Rules for passing URIs to external commands. When one rule is defined the "
-"link and tab menu will have a menu item that makes it possible to pass the "
-"the link, frame or tab URI to an external command. If several rules are "
-"defined the link and tab menu will have a submenu of items for each rule.\n"
+"Rules for passing URIs to external commands. When one rule is defined the link and tab menu will have a menu item that makes it possible to pass the the link, frame or tab URI to an external command. If several rules are defined the link and tab menu will have a submenu of items for each rule.\n"
 "\n"
-"The action and submenus are also available by binding keys to the frame-"
-"external-command, the link-external-command, and the tab-external-command "
-"actions.\n"
+"The action and submenus are also available by binding keys to the frame-external-command, the link-external-command, and the tab-external-command actions.\n"
 "\n"
-"Commands run in the background by default: elinks is still active, and they "
-"do not receive standard input. The \"foreground\" suboption reverses this "
-"behaviour: the command receives standard input and elinks is blocked.\n"
+"Commands run in the background by default: elinks is still active, and they do not receive standard input. The \"foreground\" suboption reverses this behaviour: the command receives standard input and elinks is blocked.\n"
 msgstr ""
-"Правила за прослеђивање УРИ-ја спољашњим наредбама. Када је задато једно "
-"правило, мени везе и језичка ће имати ставку која омогућава да се УРИ везе, "
-"оквира или језичка проследи спољашњој наредби. Ако је задато више правила, "
-"мени везе и језичка ће имати подмени са ставкама за свако правило.\n"
+"Правила за прослеђивање УРИ-ја спољашњим наредбама. Када је задато једно правило, мени везе и језичка ће имати ставку која омогућава да се УРИ везе, оквира или језичка проследи спољашњој наредби. Ако је задато више правила, мени везе и језичка ће имати подмени са ставкама за свако правило.\n"
 "\n"
-"Акција и подменији су такође доступни доделом тастера акцијама frame-"
-"external-command, link-external-command и tab-external-command.\n"
+"Акција и подменији су такође доступни доделом тастера акцијама frame-external-command, link-external-command и tab-external-command.\n"
 "\n"
-"Команде се подразумевано покрећу у позадини: elinks је и даље активан, а оне "
-"не примају стандардни улаз. Подопција „foreground“ обрће ово понашање: "
-"наредба прима стандардни улаз а elinks је блокиран.\n"
+"Команде се подразумевано покрећу у позадини: elinks је и даље активан, а оне не примају стандардни улаз. Подопција „foreground“ обрће ово понашање: наредба прима стандардни улаз а elinks је блокиран.\n"
 
 #: src/config/options.inc:888
 msgid "A rule for passing URI to an external command."
@@ -3864,12 +3426,8 @@ msgid "Save interval"
 msgstr "Интервал чувања"
 
 #: src/config/options.inc:912
-msgid ""
-"Interval at which to trigger information files in ~/.elinks to be saved to "
-"disk if they have changed (seconds; 0 to disable)"
-msgstr ""
-"Интервал при коме ће се чувати информативне датотеке у директоријуму ~/."
-"elinks на диск уколико су оне измењене (у секундима; 0 деактивира)"
+msgid "Interval at which to trigger information files in ~/.elinks to be saved to disk if they have changed (seconds; 0 to disable)"
+msgstr "Интервал при коме ће се чувати информативне датотеке у директоријуму ~/.elinks на диск уколико су оне измењене (у секундима; 0 деактивира)"
 
 #: src/config/options.inc:916
 msgid "Use secure file saving"
@@ -3877,41 +3435,21 @@ msgstr "Употреба безбедног чувања датотека"
 
 #: src/config/options.inc:918
 msgid ""
-"First write data to unique temporary file, then rename this file upon "
-"successfully finishing this. Note that this relates only to config files, "
-"not downloaded files. You may want to disable it if you are using some "
-"exotic permissions for concerned files. Secure file saving is automagically "
-"disabled if file is symlink.\n"
+"First write data to unique temporary file, then rename this file upon successfully finishing this. Note that this relates only to config files, not downloaded files. You may want to disable it if you are using some exotic permissions for concerned files. Secure file saving is automagically disabled if file is symlink.\n"
 "\n"
-"Warning: some systems (ie. OS/2, Win32) require that destination file "
-"doesn't exist when rename(3) is called, breaking atomicity, and reducing "
-"reliability of this feature."
+"Warning: some systems (ie. OS/2, Win32) require that destination file doesn't exist when rename(3) is called, breaking atomicity, and reducing reliability of this feature."
 msgstr ""
-"Прво ће се подаци уписивати у јединствену привремену датотеку, а ако се ово "
-"успешно заврши, онда ће та датотека бити преименована. Имајте у виду да се "
-"ово односи само на датотеке са подешавањима, а не на преузете датотеке. "
-"Можда ћете морати да ово деактивирате уколико користите неке егзотичне "
-"дозволе приступа тим датотекама. Безбедно чување датотека се аутомагично "
-"деактивира уколико је датотека симвеза.\n"
+"Прво ће се подаци уписивати у јединствену привремену датотеку, а ако се ово успешно заврши, онда ће та датотека бити преименована. Имајте у виду да се ово односи само на датотеке са подешавањима, а не на преузете датотеке. Можда ћете морати да ово деактивирате уколико користите неке егзотичне дозволе приступа тим датотекама. Безбедно чување датотека се аутомагично деактивира уколико је датотека симвеза.\n"
 "\n"
-"Упозорење: неки системи (нпр. OS/2, Win32) захтевају да одредишна датотека "
-"не постоји када се позове rename(3), што квари атомичност и смањује "
-"поузданост ове могућности."
+"Упозорење: неки системи (нпр. OS/2, Win32) захтевају да одредишна датотека не постоји када се позове rename(3), што квари атомичност и смањује поузданост ове могућности."
 
 #: src/config/options.inc:930
 msgid "Use fsync(3) with secure file saving"
 msgstr "Употреба fsync(3) при безбедном чувању датотека"
 
 #: src/config/options.inc:932
-msgid ""
-"When using secure file saving, call fsync(3), if the OS supports it, to "
-"force the OS immediately to write the data to permanent storage. This is "
-"optional for those who wish to avoid excessive disk I/O."
-msgstr ""
-"При безбедном чувању датотека, позиваће се fsync(3), уколико га ОС подржава, "
-"да би приморао ОС да тренутно упише податке на медијум за трајно "
-"складиштење. Ово није обавезно за оне који желе да избегну претеране У/И "
-"операције са диском."
+msgid "When using secure file saving, call fsync(3), if the OS supports it, to force the OS immediately to write the data to permanent storage. This is optional for those who wish to avoid excessive disk I/O."
+msgstr "При безбедном чувању датотека, позиваће се fsync(3), уколико га ОС подржава, да би приморао ОС да тренутно упише податке на медијум за трајно складиштење. Ово није обавезно за оне који желе да избегну претеране У/И операције са диском."
 
 #. Keep options in alphabetical order.
 #: src/config/options.inc:941
@@ -3924,13 +3462,11 @@ msgstr "Опције терминала."
 
 #: src/config/options.inc:947
 msgid "Options specific to this terminal type (according to $TERM value)."
-msgstr ""
-"Опције специфичне за ову врсту терминала (према вредности променљиве $TERM)."
+msgstr "Опције специфичне за ову врсту терминала (према вредности променљиве $TERM)."
 
 #: src/config/options.inc:974
 msgid ""
-"Terminal type; matters mostly only when drawing frames and dialog box "
-"borders:\n"
+"Terminal type; matters mostly only when drawing frames and dialog box borders:\n"
 "0 is dumb terminal type, ASCII art\n"
 "1 is VT100, simple but portable\n"
 "2 is Linux, you get double frames and other goodies\n"
@@ -3938,8 +3474,7 @@ msgid ""
 "4 is FreeBSD\n"
 "5 is fbterm"
 msgstr ""
-"Врста терминала: углавном је од значаја при исцртавању оквира и ивица "
-"дијалога:\n"
+"Врста терминала: углавном је од значаја при исцртавању оквира и ивица дијалога:\n"
 "0 означава глупи терминал, ASCII art\n"
 "1 означава VT100, једноставно али преносиво\n"
 "2 означава Linux, добићете двоструке оквире и друге погодности\n"
@@ -3953,37 +3488,21 @@ msgstr "Увек кодирати xterm наслов у ISO-8859-1"
 
 #: src/config/options.inc:985
 msgid ""
-"When updating the window title of xterm or a similar terminal emulator, "
-"encode the title in ISO-8859-1 (Latin-1), rather than in the charset used "
-"for other text in the window. Cyrillic and other characters get replaced "
-"with Latin ones. Xterm requires this unless you explicitly enable UTF-8 "
-"titles in it.\n"
+"When updating the window title of xterm or a similar terminal emulator, encode the title in ISO-8859-1 (Latin-1), rather than in the charset used for other text in the window. Cyrillic and other characters get replaced with Latin ones. Xterm requires this unless you explicitly enable UTF-8 titles in it.\n"
 "\n"
-"If this option does not take effect immediately, try switching to a "
-"different page so that ELinks notices it needs to update the title."
+"If this option does not take effect immediately, try switching to a different page so that ELinks notices it needs to update the title."
 msgstr ""
-"Када се ажурира наслов прозора xterm-а или сличног емулатора терминала, "
-"наслов ће бити кодиран у ISO-8859-1 (Latin-1) уместо у скупу знакова који се "
-"користи за други текст у прозору. Ћирилична и друга слова ће бити замењена "
-"латиничним. Ово се захтева од стране xterm-а, осим ако у њему експлицитно "
-"укључите UTF-8 наслове.\n"
+"Када се ажурира наслов прозора xterm-а или сличног емулатора терминала, наслов ће бити кодиран у ISO-8859-1 (Latin-1) уместо у скупу знакова који се користи за други текст у прозору. Ћирилична и друга слова ће бити замењена латиничним. Ово се захтева од стране xterm-а, осим ако у њему експлицитно укључите UTF-8 наслове.\n"
 "\n"
-"Ако ова опција не проради одмах, пробајте да се пребаците на другу страницу, "
-"тако да ELinks примети да треба да ажурира наслов."
+"Ако ова опција не проради одмах, пробајте да се пребаците на другу страницу, тако да ELinks примети да треба да ажурира наслов."
 
 #: src/config/options.inc:996 src/dialogs/options.c:230
 msgid "Switch fonts for line drawing"
 msgstr "Пребацивање фонтова за исцртавање линија"
 
 #: src/config/options.inc:998
-msgid ""
-"Switch fonts when drawing lines, enabling both local characters and lines "
-"working at the same time. ELinks uses this option only if UTF-8 I/O is "
-"disabled and the terminal type is Linux or FreeBSD."
-msgstr ""
-"Пребацивање фонтова при исцртавању линија, што омогућава да у исто време "
-"функционишу и неенглески знаци и линије. ELinks користи ову опцију само ако "
-"је UTF-8 У/И искључен и тип терминала је Linux или FreeBSD."
+msgid "Switch fonts when drawing lines, enabling both local characters and lines working at the same time. ELinks uses this option only if UTF-8 I/O is disabled and the terminal type is Linux or FreeBSD."
+msgstr "Пребацивање фонтова при исцртавању линија, што омогућава да у исто време функционишу и неенглески знаци и линије. ELinks користи ову опцију само ако је UTF-8 У/И искључен и тип терминала је Linux или FreeBSD."
 
 #. When CONFIG_UTF8 is defined, any code that reads the "utf_8_io"
 #. * option should also check whether the "codepage" option is UTF-8,
@@ -3995,51 +3514,32 @@ msgid "UTF-8 I/O"
 msgstr "UTF-8 У/И"
 
 #: src/config/options.inc:1010
-msgid ""
-"Enable I/O in UTF-8 for Unicode terminals. Note that currently, only the "
-"subset of UTF-8 according to terminal codepage is used. ELinks ignores this "
-"option if the terminal codepage is UTF-8."
-msgstr ""
-"Активирање У/И у стандарду UTF-8 за терминале који подржавају Уникод. Имајте "
-"у виду да се тренутно користи само подскуп стандарда UTF-8 према кодној "
-"страници терминала. ELinks игнорише ову опцију ако је кодна страна терминала "
-"UTF-8."
+msgid "Enable I/O in UTF-8 for Unicode terminals. Note that currently, only the subset of UTF-8 according to terminal codepage is used. ELinks ignores this option if the terminal codepage is UTF-8."
+msgstr "Активирање У/И у стандарду UTF-8 за терминале који подржавају Уникод. Имајте у виду да се тренутно користи само подскуп стандарда UTF-8 према кодној страници терминала. ELinks игнорише ову опцију ако је кодна страна терминала UTF-8."
 
 #: src/config/options.inc:1016 src/dialogs/options.c:238 src/main/version.c:156
 msgid "Combining characters"
 msgstr "Комбинујући знакови"
 
 #: src/config/options.inc:1018
-msgid ""
-"Enable combining characters. It works only with the xterm in UTF-8 mode."
-msgstr ""
-"Активирање комбинујућих знакова. Функционише само са xterm-ом у режиму UTF-8."
+msgid "Enable combining characters. It works only with the xterm in UTF-8 mode."
+msgstr "Активирање комбинујућих знакова. Функционише само са xterm-ом у режиму UTF-8."
 
 #: src/config/options.inc:1022 src/dialogs/options.c:231
 msgid "Restrict frames in cp850/852"
 msgstr "Ограничавање оквира у cp850/852"
 
 #: src/config/options.inc:1024
-msgid ""
-"Restrict the characters used when drawing lines. Makes sense only with linux "
-"terminals using the cp850/852 character sets."
-msgstr ""
-"Ограничавање знакова који се користе при исцртавању линија. Има смисла само "
-"са терминалима врсте Linux који користе скупове знакова cp850/852."
+msgid "Restrict the characters used when drawing lines. Makes sense only with linux terminals using the cp850/852 character sets."
+msgstr "Ограничавање знакова који се користе при исцртавању линија. Има смисла само са терминалима врсте Linux који користе скупове знакова cp850/852."
 
 #: src/config/options.inc:1028 src/dialogs/options.c:232
 msgid "Block cursor"
 msgstr "Курсор у облику блока"
 
 #: src/config/options.inc:1030
-msgid ""
-"Move cursor to bottom right corner when done drawing. This is particularly "
-"useful when we have a block cursor, so that inversed text is displayed "
-"correctly."
-msgstr ""
-"Померање курсора у доњи десни угао при завршетку исцртавања. Ово је нарочито "
-"корисно када је курсор у облику блока, па се онда исправно приказује "
-"инвертовани текст."
+msgid "Move cursor to bottom right corner when done drawing. This is particularly useful when we have a block cursor, so that inversed text is displayed correctly."
+msgstr "Померање курсора у доњи десни угао при завршетку исцртавања. Ово је нарочито корисно када је курсор у облику блока, па се онда исправно приказује инвертовани текст."
 
 #. The list of modes must be at the end of this string
 #. * because AsciiDoc 7.1.2 does not support continuing
@@ -4048,12 +3548,9 @@ msgstr ""
 #. * "en" (English) translation.  (See doc/Makefile.)
 #: src/config/options.inc:1041
 msgid ""
-"The color mode controls what colors are used and how they are output to the "
-"terminal.\n"
+"The color mode controls what colors are used and how they are output to the terminal.\n"
 "\n"
-"Some modes may have been disabled at compile time. The Setup -> Terminal "
-"options dialog lists the modes supported by this executable. If you select "
-"an unsupported mode, ELinks uses 16 colors.\n"
+"Some modes may have been disabled at compile time. The Setup -> Terminal options dialog lists the modes supported by this executable. If you select an unsupported mode, ELinks uses 16 colors.\n"
 "\n"
 "The color modes are:\n"
 "0 is mono mode, only 2 colors are used\n"
@@ -4062,12 +3559,9 @@ msgid ""
 "3 is 256 color mode, uses XTerm RGB codes\n"
 "4 is true color mode, uses konsole RGB codes"
 msgstr ""
-"Режим боја управља употребом боја и начином на који се оне приказују на "
-"терминалу.\n"
+"Режим боја управља употребом боја и начином на који се оне приказују на терминалу.\n"
 "\n"
-"Неки режими су можда онемогућени приликом компајлирања. Дијалог Подешавања -"
-"> Опције терминала приказује режиме које подржава ова извршна датотека. "
-"Уколико изаберете неподржани режим, ELinks користи 16 боја.\n"
+"Неки режими су можда онемогућени приликом компајлирања. Дијалог Подешавања -> Опције терминала приказује режиме које подржава ова извршна датотека. Уколико изаберете неподржани режим, ELinks користи 16 боја.\n"
 "\n"
 "Режими боја су следећи:\n"
 "0 монохроматски, користе се само 2 боје\n"
@@ -4081,20 +3575,8 @@ msgid "Transparency"
 msgstr "Провидност"
 
 #: src/config/options.inc:1058
-msgid ""
-"If we should not set the background to black. This is particularly useful "
-"when we have a terminal (typically in some windowing environment) with a "
-"background image or a transparent background - it will be visible in ELinks "
-"as well (but ELinks document color handling will still assume the background "
-"is black so if you have a bright background you might experience contrast "
-"problems). Note that this option makes sense only when colors are enabled."
-msgstr ""
-"Ово одређује да ли се позадина неће постављати на црну. То је нарочито "
-"корисно када имамо терминал (обично у неком прозорском окружењу) са "
-"позадинском сликом или провидну позадину, која ће се видети и у ELinks-у "
-"(али ELinks-ов начин руковања бојама документа ће и даље претпостављати да "
-"је позадина црна, па ако имате светлу позадину, може доћи до проблема са "
-"контрастом). Приметите да ова опција има смисла само када су активиране боје."
+msgid "If we should not set the background to black. This is particularly useful when we have a terminal (typically in some windowing environment) with a background image or a transparent background - it will be visible in ELinks as well (but ELinks document color handling will still assume the background is black so if you have a bright background you might experience contrast problems). Note that this option makes sense only when colors are enabled."
+msgstr "Ово одређује да ли се позадина неће постављати на црну. То је нарочито корисно када имамо терминал (обично у неком прозорском окружењу) са позадинском сликом или провидну позадину, која ће се видети и у ELinks-у (али ELinks-ов начин руковања бојама документа ће и даље претпостављати да је позадина црна, па ако имате светлу позадину, може доћи до проблема са контрастом). Приметите да ова опција има смисла само када су активиране боје."
 
 #: src/config/options.inc:1068 src/dialogs/options.c:233
 msgid "Italic"
@@ -4109,13 +3591,8 @@ msgid "If we should use underline or enhance the color instead."
 msgstr "Да ли да се користи подвлачење или појачавање боја."
 
 #: src/config/options.inc:1079
-msgid ""
-"Codepage of charset used for displaying content on terminal. 'System' stands "
-"for a codepage determined by a selected locale."
-msgstr ""
-"Кодна страна скупа знакова који се користи за приказивање садржаја на "
-"терминалу. „System“ означава кодну страну која ће бити одређена изабраним "
-"локалитетом."
+msgid "Codepage of charset used for displaying content on terminal. 'System' stands for a codepage determined by a selected locale."
+msgstr "Кодна страна скупа знакова који се користи за приказивање садржаја на терминалу. „System“ означава кодну страну која ће бити одређена изабраним локалитетом."
 
 #. Keep options in alphabetical order.
 #: src/config/options.inc:1087
@@ -4229,7 +3706,7 @@ msgstr "Означене ставке менија"
 
 #: src/config/options.inc:1170
 msgid "Marked menu item colors."
-msgstr "Боје означених ставки менија"
+msgstr "Боје означених ставки менија."
 
 #: src/config/options.inc:1174
 msgid "Menu item hotkey colors."
@@ -4452,8 +3929,7 @@ msgid "Unvisited tab"
 msgstr "Непосећени језичак"
 
 #: src/config/options.inc:1306
-msgid ""
-"Tab colors for tabs that have not been selected since they completed loading."
+msgid "Tab colors for tabs that have not been selected since they completed loading."
 msgstr "Боје језичка који није изабрани од завршетка учитавања."
 
 #: src/config/options.inc:1309
@@ -4521,62 +3997,40 @@ msgid "Minimal height of listbox widget"
 msgstr "Минимална висина листе"
 
 #: src/config/options.inc:1347
-msgid ""
-"Minimal height of the listbox widget (used e.g. for bookmarks or global "
-"history)."
-msgstr ""
-"Минимална висина виџета листе (нпр. код обележивача или глобалне историје)."
+msgid "Minimal height of the listbox widget (used e.g. for bookmarks or global history)."
+msgstr "Минимална висина виџета листе (нпр. код обележивача или глобалне историје)."
 
 #: src/config/options.inc:1350
 msgid "Drop shadows"
 msgstr "Бацање сенки"
 
 #: src/config/options.inc:1352
-msgid ""
-"Make dialogs drop shadows (the shadows are solid, you can adjust their color "
-"by ui.colors.*.dialog.shadow). You may also want to eliminate the wide "
-"borders by adjusting setup.h."
-msgstr ""
-"Чини да дијалози бацају сенке (сенке су непровидне, а њихову боју можете "
-"подесити преко опције ui.colors.*.dialog.shadow). Можда ћете такође желети "
-"да уклоните широке ивице подешавањем заглавља setup.h."
+msgid "Make dialogs drop shadows (the shadows are solid, you can adjust their color by ui.colors.*.dialog.shadow). You may also want to eliminate the wide borders by adjusting setup.h."
+msgstr "Чини да дијалози бацају сенке (сенке су непровидне, а њихову боју можете подесити преко опције ui.colors.*.dialog.shadow). Можда ћете такође желети да уклоните широке ивице подешавањем заглавља setup.h."
 
 #: src/config/options.inc:1357
 msgid "Underline menu hotkeys"
 msgstr "Подвлачење пречица менија"
 
 #: src/config/options.inc:1359
-msgid ""
-"Whether to underline hotkeys in menus to make them more visible. Requires "
-"that underlining is enabled for the terminal."
-msgstr ""
-"Да ли ће се подвлачити пречице у менијима како би биле видљивије. Захтева "
-"активирање подвлачења на терминалу."
+msgid "Whether to underline hotkeys in menus to make them more visible. Requires that underlining is enabled for the terminal."
+msgstr "Да ли ће се подвлачити пречице у менијима како би биле видљивије. Захтева активирање подвлачења на терминалу."
 
 #: src/config/options.inc:1363
 msgid "Underline button shortcuts"
 msgstr "Подвлачење пречица дугмади"
 
 #: src/config/options.inc:1365
-msgid ""
-"Whether to underline button shortcuts to make them more visible. Requires "
-"that underlining is enabled for the terminal."
-msgstr ""
-"Да ли ће се подвлачити пречице дугмади како би биле видљивије. Захтева "
-"активирање подвлачења на терминалу."
+msgid "Whether to underline button shortcuts to make them more visible. Requires that underlining is enabled for the terminal."
+msgstr "Да ли ће се подвлачити пречице дугмади како би биле видљивије. Захтева активирање подвлачења на терминалу."
 
 #: src/config/options.inc:1370
 msgid "Timer options"
 msgstr "Опције тајмера"
 
 #: src/config/options.inc:1372
-msgid ""
-"Timed action after certain interval of user inactivity. Someone can even "
-"find this useful, although you may not believe that."
-msgstr ""
-"Акције које се извршавају после одређеног интервала неактивности корисника. "
-"Некоме ће ово чак бити и од користи, иако ће вам можда бити тешко да у то "
-"поверујете."
+msgid "Timed action after certain interval of user inactivity. Someone can even find this useful, although you may not believe that."
+msgstr "Акције које се извршавају после одређеног интервала неактивности корисника. Некоме ће ово чак бити и од користи, иако ће вам можда бити тешко да у то поверујете."
 
 #: src/config/options.inc:1379
 msgid ""
@@ -4607,12 +4061,8 @@ msgid "Duration"
 msgstr "Трајање"
 
 #: src/config/options.inc:1394
-msgid ""
-"Inactivity timeout in seconds. The maximum of one day should be enough for "
-"just everyone (TM)."
-msgstr ""
-"Дозвољено време неактивности у секундима. Максимум од једног дана би свима "
-"требало да буде довољан (ТМ)."
+msgid "Inactivity timeout in seconds. The maximum of one day should be enough for just everyone (TM)."
+msgstr "Дозвољено време неактивности у секундима. Максимум од једног дана би свима требало да буде довољан (ТМ)."
 
 #: src/config/options.inc:1399
 msgid "Keybinding action to be triggered when timer reaches zero."
@@ -4655,11 +4105,8 @@ msgid "Wrap-around tabs cycling"
 msgstr "Кружно кретање кроз језичке"
 
 #: src/config/options.inc:1420
-msgid ""
-"When moving right from the last tab, jump to the first one, and vice versa."
-msgstr ""
-"Када се на последњем језичку притисне стрелица надесно, скочиће на први, и "
-"обрнуто."
+msgid "When moving right from the last tab, jump to the first one, and vice versa."
+msgstr "Када се на последњем језичку притисне стрелица надесно, скочиће на први, и обрнуто."
 
 #: src/config/options.inc:1423
 msgid "Confirm tab closing"
@@ -4683,12 +4130,8 @@ msgid "Language"
 msgstr "Језик"
 
 #: src/config/options.inc:1433
-msgid ""
-"Language of user interface. 'System' means that the language will be "
-"extracted from the environment dynamically."
-msgstr ""
-"Језик корисничког интерфејса. „System“ значи да ће језик бити динамички "
-"изведен из променљивих окружења."
+msgid "Language of user interface. 'System' means that the language will be extracted from the environment dynamically."
+msgstr "Језик корисничког интерфејса. „System“ значи да ће језик бити динамички изведен из променљивих окружења."
 
 #: src/config/options.inc:1437
 msgid "Display menu bar always"
@@ -4719,24 +4162,16 @@ msgid "Display goto dialog in new tabs"
 msgstr "Приказивање дијалога „Иди на“ у новим језичцима"
 
 #: src/config/options.inc:1451
-msgid ""
-"Pop up goto dialog in newly created tabs when there's no homepage set. This "
-"means also showing goto dialog on startup."
-msgstr ""
-"Отвара дијалог „Иди на“ у новокреираним језичцима када није задата почетна "
-"страница. Ово такође значи да ће се тај дијалог приказивати при покретању."
+msgid "Pop up goto dialog in newly created tabs when there's no homepage set. This means also showing goto dialog on startup."
+msgstr "Отвара дијалог „Иди на“ у новокреираним језичцима када није задата почетна страница. Ово такође значи да ће се тај дијалог приказивати при покретању."
 
 #: src/config/options.inc:1455
 msgid "Show a message box when file is saved successfully"
 msgstr "Приказивање дијалога са поруком када је датотека успешно сачувана"
 
 #: src/config/options.inc:1457
-msgid ""
-"When you pressed a [ Save ] button in some manager, this option will make "
-"sure that a box confirming success of the operation will pop up."
-msgstr ""
-"Када притиснете дугме [ Сачувај ] у неком управљачу, ова опција ће осигурати "
-"да се отвори дијалог који потврђује успешност операције."
+msgid "When you pressed a [ Save ] button in some manager, this option will make sure that a box confirming success of the operation will pop up."
+msgstr "Када притиснете дугме [ Сачувај ] у неком управљачу, ова опција ће осигурати да се отвори дијалог који потврђује успешност операције."
 
 #: src/config/options.inc:1462
 msgid "Sessions"
@@ -4780,14 +4215,11 @@ msgstr "Назив фасцикле за аутоматско чување и о
 
 #: src/config/options.inc:1480
 msgid ""
-"Name of the bookmarks folder used for auto saving and restoring session. The "
-"name has to be unique. Any folders with the same name will be deleted.\n"
+"Name of the bookmarks folder used for auto saving and restoring session. The name has to be unique. Any folders with the same name will be deleted.\n"
 "\n"
 "This only makes sense with bookmark support."
 msgstr ""
-"Назив фасцикле обележивача која се користи при аутоматском чувању и "
-"обнављању сесије. Он мора бити јединствен. Свака фасцикла са истим називом "
-"ће бити обрисана.\n"
+"Назив фасцикле обележивача која се користи при аутоматском чувању и обнављању сесије. Он мора бити јединствен. Свака фасцикла са истим називом ће бити обрисана.\n"
 "\n"
 "Ово има смисла једино уз подршку за обележиваче."
 
@@ -4796,26 +4228,16 @@ msgid "Fork on start"
 msgstr "Fork-овање на почетку"
 
 #: src/config/options.inc:1488
-msgid ""
-"Fork on start to let other terminals function even if the first terminal "
-"exits."
-msgstr ""
-"Fork-овање на почетку, како би се другим терминалима омогућило да "
-"функционишу чак и ако се изађе из првог терминала."
+msgid "Fork on start to let other terminals function even if the first terminal exits."
+msgstr "Fork-овање на почетку, како би се другим терминалима омогућило да функционишу чак и ако се изађе из првог терминала."
 
 #: src/config/options.inc:1491
 msgid "Homepage URI"
 msgstr "УРИ почетне странице"
 
 #: src/config/options.inc:1493
-msgid ""
-"The URI to load either at startup time when no URI was given on the command "
-"line or when requested by the goto-url-home action. Set to \"\" if the "
-"environment variable WWW_HOME should be used as homepage URI instead."
-msgstr ""
-"УРИ који ће се учитати или при покретању, ако ниједан УРИ није задат у "
-"командној линији, или када се то захтева акцијом goto-url-home. Поставите на "
-"„“ ако желите да се као УРИ уместо тога користи променљива окружења WWW_HOME."
+msgid "The URI to load either at startup time when no URI was given on the command line or when requested by the goto-url-home action. Set to \"\" if the environment variable WWW_HOME should be used as homepage URI instead."
+msgstr "УРИ који ће се учитати или при покретању, ако ниједан УРИ није задат у командној линији, или када се то захтева акцијом goto-url-home. Поставите на „“ ако желите да се као УРИ уместо тога користи променљива окружења WWW_HOME."
 
 #: src/config/options.inc:1498
 msgid "Keep session active"
@@ -4823,24 +4245,15 @@ msgstr "Одржавање сесије активном"
 
 #: src/config/options.inc:1500
 msgid "Keep the session active even if the last terminal exits."
-msgstr ""
-"Сесија ће се одржавати активном чак и када се изађе из последњег терминала."
+msgstr "Сесија ће се одржавати активном чак и када се изађе из последњег терминала."
 
 #: src/config/options.inc:1503
 msgid "Clipboard filename"
 msgstr "Датотека клипборда"
 
 #: src/config/options.inc:1505
-msgid ""
-"The filename of the clipboard. The 'copy-clipboard' action will append to "
-"it. This file can be also a named pipe. See contrib/clipboard/clip.sh for "
-"sample implementation. Note this file must exists before copying to the "
-"clipboard."
-msgstr ""
-"Датотека клипборда. Акција „copy-clipboard“ ће дописивати у њу. Ова датотека "
-"може бити и именована цев. Видите contrib/clipboard/clip.sh за пример "
-"имплементације. Приметите да ова датотека мора постојати пре копирања на "
-"клипборд."
+msgid "The filename of the clipboard. The 'copy-clipboard' action will append to it. This file can be also a named pipe. See contrib/clipboard/clip.sh for sample implementation. Note this file must exists before copying to the clipboard."
+msgstr "Датотека клипборда. Акција „copy-clipboard“ ће дописивати у њу. Ова датотека може бити и именована цев. Видите contrib/clipboard/clip.sh за пример имплементације. Приметите да ова датотека мора постојати пре копирања на клипборд."
 
 #: src/config/options.inc:1510
 msgid "Date format"
@@ -4857,9 +4270,7 @@ msgstr "Деактивирање миша"
 
 #: src/config/options.inc:1519
 msgid "Disable mouse. Changes take effect at the next elinks restart."
-msgstr ""
-"Деактивирање миша. Промене ступају на снагу приликом следећег покретања "
-"elinks-а."
+msgstr "Деактивирање миша. Промене ступају на снагу приликом следећег покретања elinks-а."
 
 #: src/config/options.inc:1523
 msgid "Back to exit"
@@ -4882,13 +4293,8 @@ msgid "Set window title"
 msgstr "Постављање наслова прозора"
 
 #: src/config/options.inc:1533
-msgid ""
-"Set the window title when running in a windowing environment in an xterm-"
-"like terminal. This way the document's title is shown on the window titlebar."
-msgstr ""
-"Постављање наслова прозора при извршавању под прозорским окружењем у xterm-"
-"оликом терминалу. На тај начин ће наслов документа бити приказан у насловној "
-"линији прозора."
+msgid "Set the window title when running in a windowing environment in an xterm-like terminal. This way the document's title is shown on the window titlebar."
+msgstr "Постављање наслова прозора при извршавању под прозорским окружењем у xterm-оликом терминалу. На тај начин ће наслов документа бити приказан у насловној линији прозора."
 
 #: src/config/opttypes.c:54
 msgid "Read error"
@@ -5019,19 +4425,8 @@ msgid "Paranoid security"
 msgstr "Параноидна безбедност"
 
 #: src/cookies/cookies.c:110
-msgid ""
-"When enabled, we'll require three dots in cookies domain for all non-"
-"international domains (instead of just two dots). Some countries have "
-"generic second level domains (eg. .com.pl, .co.uk) and allowing sites to set "
-"cookies for these generic domains could potentially be very bad. Note, it is "
-"off by default as it breaks a lot of sites."
-msgstr ""
-"Када је ово активирано, захтеваће се три тачке у домену колачића код свих "
-"неинтернационалних домена, уместо само две тачке. Неке земље имају опште "
-"домене другог нивоа (нпр. .com.pl, co.uk) па би дозвољавање сајтовима да "
-"постављају колачиће за ове опште домене потенцијално било веома лоше. Имајте "
-"у виду да је ова опција подразумевано искључена, јер квари понашање доста "
-"сајтова."
+msgid "When enabled, we'll require three dots in cookies domain for all non-international domains (instead of just two dots). Some countries have generic second level domains (eg. .com.pl, .co.uk) and allowing sites to set cookies for these generic domains could potentially be very bad. Note, it is off by default as it breaks a lot of sites."
+msgstr "Када је ово активирано, захтеваће се три тачке у домену колачића код свих неинтернационалних домена, уместо само две тачке. Неке земље имају опште домене другог нивоа (нпр. .com.pl, co.uk) па би дозвољавање сајтовима да постављају колачиће за ове опште домене потенцијално било веома лоше. Имајте у виду да је ова опција подразумевано искључена, јер квари понашање доста сајтова."
 
 #: src/cookies/cookies.c:117
 msgid "Saving"
@@ -5046,12 +4441,8 @@ msgid "Resaving"
 msgstr "Поновно чување"
 
 #: src/cookies/cookies.c:124
-msgid ""
-"Save cookies after each change in cookies list? No effect when cookie saving "
-"(cookies.save) is off."
-msgstr ""
-"Да ли ће се чувати колачићи после сваке промене у листи колачића. Ово нема "
-"ефекта када је чување колачића (опција cookies.save) искључено."
+msgid "Save cookies after each change in cookies list? No effect when cookie saving (cookies.save) is off."
+msgstr "Да ли ће се чувати колачићи после сваке промене у листи колачића. Ово нема ефекта када је чување колачића (опција cookies.save) искључено."
 
 #: src/cookies/cookies.c:823
 msgid "Cannot save cookies"
@@ -5366,9 +4757,7 @@ msgid ""
 "\n"
 "%set al.\n"
 "\n"
-"This program is free software; you can redistribute it and/or modify it "
-"under the terms of the GNU General Public License as published by the Free "
-"Software Foundation, specifically version 2 of the License."
+"This program is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, specifically version 2 of the License."
 msgstr ""
 "ELinks %s\n"
 "\n"
@@ -5376,9 +4765,7 @@ msgstr ""
 "\n"
 "Превод на српски: Страхиња Радић, <contact@strahinja.org>\n"
 "\n"
-"Овај програм је слободни софтвер; можете га расподелити и/или мењати под "
-"одредбана ГНУ-ове опште јавне лиценце коју је објавила Задужбина за слободни "
-"софтвер, и то искључиво верзије 2 те лиценце."
+"Овај програм је слободни софтвер; можете га расподелити и/или мењати под одредбана ГНУ-ове опште јавне лиценце коју је објавила Задужбина за слободни софтвер, и то искључиво верзије 2 те лиценце."
 
 #: src/dialogs/info.c:170 src/dialogs/info.c:284
 msgid "Resources"
@@ -5485,8 +4872,8 @@ msgstr[1] "%ld се освежавају"
 msgstr[2] "%ld се освежава"
 
 #. name:
-#: src/dialogs/info.c:236 src/ecmascript/ecmascript.c:60
-#: src/ecmascript/ecmascript.c:758
+#: src/dialogs/info.c:236 src/ecmascript/ecmascript.c:55
+#: src/ecmascript/ecmascript.c:741
 msgid "ECMAScript"
 msgstr "ECMAScript"
 
@@ -5552,8 +4939,7 @@ msgstr "Излазак из ELinks-а"
 
 #: src/dialogs/menu.c:128
 msgid "Do you really want to exit ELinks (and terminate all downloads)?"
-msgstr ""
-"Да ли заисте желите да изађете из ELinks-а (и прекинете сва преузимања)?"
+msgstr "Да ли заисте желите да изађете из ELinks-а (и прекинете сва преузимања)?"
 
 #: src/dialogs/menu.c:130
 msgid "Do you really want to exit ELinks?"
@@ -6134,29 +5520,16 @@ msgid "Ignore \"display: none\""
 msgstr "Игнорисање „display: none“"
 
 #: src/document/css/css.c:41
-msgid ""
-"When enabled, elements are rendered, even when their display property has "
-"the value \"none\". Because ELinks's CSS support is still very incomplete, "
-"this setting can improve the way that some documents are rendered."
-msgstr ""
-"Када је активирано, елементи се исцртавају чак и када њихово својство "
-"„display“ има вредност „none“. Пошто је ELinks-ова подршка за CSS још увек "
-"веома непотпуна, ова поставка може побољшати начин на који се неки документи "
-"исцртавају."
+msgid "When enabled, elements are rendered, even when their display property has the value \"none\". Because ELinks's CSS support is still very incomplete, this setting can improve the way that some documents are rendered."
+msgstr "Када је активирано, елементи се исцртавају чак и када њихово својство „display“ има вредност „none“. Пошто је ELinks-ова подршка за CSS још увек веома непотпуна, ова поставка може побољшати начин на који се неки документи исцртавају."
 
 #: src/document/css/css.c:46
 msgid "Import external style sheets"
 msgstr "Увоз спољашњег скупа стилова"
 
 #: src/document/css/css.c:48
-msgid ""
-"When enabled any external style sheets that are imported from either CSS "
-"itself using the @import keyword or from the HTML using <link> tags in the "
-"document header will also be downloaded."
-msgstr ""
-"Када је ово активирано, биће преузимани сви спољашњи скупови стилова, било "
-"они који се увозе из самог CSS-а преко кључне речи @import, било они из HTML-"
-"а преко ознака <link> у заглављу документа."
+msgid "When enabled any external style sheets that are imported from either CSS itself using the @import keyword or from the HTML using <link> tags in the document header will also be downloaded."
+msgstr "Када је ово активирано, биће преузимани сви спољашњи скупови стилова, било они који се увозе из самог CSS-а преко кључне речи @import, било они из HTML-а преко ознака <link> у заглављу документа."
 
 #: src/document/css/css.c:53
 msgid "Default style sheet"
@@ -6164,16 +5537,11 @@ msgstr "Подразумевани скуп стилова"
 
 #: src/document/css/css.c:55
 msgid ""
-"The path to the file containing the default user defined Cascading Style "
-"Sheet. It can be used to control the basic layout of HTML documents. The "
-"path is assumed to be relative to ELinks' home directory.\n"
+"The path to the file containing the default user defined Cascading Style Sheet. It can be used to control the basic layout of HTML documents. The path is assumed to be relative to ELinks' home directory.\n"
 "\n"
 "Leave as \"\" to use built-in document styling."
 msgstr ""
-"Путања ка датотеци која садржи подразумеване корисничке каскадне скупове "
-"стилова. Ово се може користити да се управља основним изгледом HTML "
-"докумената. Претпоставља се да се путања односи на основни директоријум "
-"ELinks-а.\n"
+"Путања ка датотеци која садржи подразумеване корисничке каскадне скупове стилова. Ово се може користити да се управља основним изгледом HTML докумената. Претпоставља се да се путања односи на основни директоријум ELinks-а.\n"
 "\n"
 "Оставите као „“ (празно) да би се користили уграђени стилови докумената."
 
@@ -6182,83 +5550,70 @@ msgid "Media types"
 msgstr "Врсте медија"
 
 #: src/document/css/css.c:64
-msgid ""
-"CSS media types that ELinks claims to support, separated with commas. The "
-"\"all\" type is implied. Currently, only ASCII characters work reliably "
-"here.  See CSS2 section 7: http://www.w3.org/TR/1998/REC-CSS2-19980512/media."
-"html"
-msgstr ""
-"CSS media типови за које ELinks тврди да их подржава, раздвојени запетама. "
-"Тип „all“ се имплицитно подразумева. Тренутно овде поуздано функционишу само "
-"ASCII знакови. Видети CSS2 секцију 7: http://www.w3.org/TR/1998/REC-"
-"CSS2-19980512/media.html"
+msgid "CSS media types that ELinks claims to support, separated with commas. The \"all\" type is implied. Currently, only ASCII characters work reliably here.  See CSS2 section 7: http://www.w3.org/TR/1998/REC-CSS2-19980512/media.html"
+msgstr "CSS media типови за које ELinks тврди да их подржава, раздвојени запетама. Тип „all“ се имплицитно подразумева. Тренутно овде поуздано функционишу само ASCII знакови. Видети CSS2 секцију 7: http://www.w3.org/TR/1998/REC-CSS2-19980512/media.html"
 
-#: src/ecmascript/ecmascript.c:62
+#: src/ecmascript/ecmascript.c:57
 msgid "ECMAScript options."
 msgstr "Опције ECMAScript-а."
 
-#: src/ecmascript/ecmascript.c:66
+#: src/ecmascript/ecmascript.c:61
 msgid "Whether to run those scripts inside of documents."
 msgstr "Да ли да се покрећу ти скриптови унутар докумената."
 
-#: src/ecmascript/ecmascript.c:68
+#: src/ecmascript/ecmascript.c:63
 msgid "Console log"
 msgstr "Дневник конзоле"
 
-#: src/ecmascript/ecmascript.c:70
+#: src/ecmascript/ecmascript.c:65
 msgid "When enabled logs will be appended to ~/.elinks/console.log."
-msgstr ""
-"Када је активирано, сви дневници ће бити дописани у ~/.elinks/console.log."
+msgstr "Када је активирано, сви дневници ће бити дописани у ~/.elinks/console.log."
 
-#: src/ecmascript/ecmascript.c:72
+#: src/ecmascript/ecmascript.c:67
 msgid "Script error reporting"
 msgstr "Пријављивање грешака у скриптовима"
 
-#: src/ecmascript/ecmascript.c:74
+#: src/ecmascript/ecmascript.c:69
 msgid "Open a message box when a script reports an error."
 msgstr "Отварање дијалога када скрипт пријави грешку."
 
-#: src/ecmascript/ecmascript.c:76
+#: src/ecmascript/ecmascript.c:71
 msgid "Ignore <noscript> content"
 msgstr "Игнорисање <noscript> садржаја"
 
-#: src/ecmascript/ecmascript.c:78
-msgid ""
-"Whether to ignore content enclosed by the <noscript> tag when ECMAScript is "
-"enabled."
-msgstr ""
-"Да ли ће се игнорисати садржај окружен <noscript> ознакама када је омогућен "
-"ECMAScript."
+#: src/ecmascript/ecmascript.c:73
+msgid "Whether to ignore content enclosed by the <noscript> tag when ECMAScript is enabled."
+msgstr "Да ли ће се игнорисати садржај окружен <noscript> ознакама када је омогућен ECMAScript."
 
-#: src/ecmascript/ecmascript.c:81
+#: src/ecmascript/ecmascript.c:76
 msgid "Maximum execution time"
 msgstr "Максимално дозвољено време извршавања"
 
-#: src/ecmascript/ecmascript.c:83
+#: src/ecmascript/ecmascript.c:78
 msgid "Maximum execution time in seconds for a script."
 msgstr "Максимално дозвољено време извршавања скрипта."
 
-#: src/ecmascript/ecmascript.c:85
+#: src/ecmascript/ecmascript.c:80
 msgid "Pop-up window blocking"
 msgstr "Блокирање искачућих прозора"
 
-#: src/ecmascript/ecmascript.c:87
+#: src/ecmascript/ecmascript.c:82
 msgid "Whether to disallow scripts to open new windows or tabs."
 msgstr "Да ли да се скриптовима забрани отварање нових прозора или језичака."
 
-#: src/ecmascript/ecmascript.c:160
+#: src/ecmascript/ecmascript.c:155
 msgid "Ecmascript enabled"
 msgstr "Ecmascript активиран"
 
-#: src/ecmascript/ecmascript.c:162
+#: src/ecmascript/ecmascript.c:157
 msgid "Ecmascript disabled"
 msgstr "Ecmascript деактивиран"
 
-#: src/ecmascript/ecmascript.c:505
+#: src/ecmascript/ecmascript.c:500
 msgid "JavaScript Emergency"
 msgstr "Узбуна JavaScript-а"
 
-#: src/ecmascript/ecmascript.c:507
+#: src/ecmascript/ecmascript.c:502
 #, c-format
 msgid ""
 "A script embedded in the current document was running\n"
@@ -6271,22 +5626,20 @@ msgstr ""
 "грешка и да би могао да заустави цео ELinks, па је зато\n"
 "извршавање скрипта прекинуто."
 
-#: src/ecmascript/quickjs.c:108 src/ecmascript/quickjs.c:277
-#: src/ecmascript/spidermonkey.c:114
+#: src/ecmascript/quickjs.c:107 src/ecmascript/spidermonkey.c:114
 msgid "A script embedded in the current document raised the following:\n"
 msgstr "Скрипт уграђен у текући документ је направио следећу грешку:\n"
 
-#: src/ecmascript/quickjs.c:112 src/ecmascript/quickjs.c:281
-#: src/ecmascript/spidermonkey.c:118
+#: src/ecmascript/quickjs.c:111 src/ecmascript/spidermonkey.c:118
 msgid "JavaScript Error"
 msgstr "Грешка JavaScript-а"
 
 #. name:
-#: src/ecmascript/quickjs.c:398
+#: src/ecmascript/quickjs.c:465
 msgid "QuickJS"
 msgstr "QuickJS"
 
-#: src/ecmascript/quickjs/window.c:399 src/ecmascript/spidermonkey/window.c:274
+#: src/ecmascript/quickjs/window.c:371 src/ecmascript/spidermonkey/window.c:270
 msgid "JavaScript Alert"
 msgstr "Упозорење JavaScript-а"
 
@@ -6352,12 +5705,10 @@ msgstr "Образац није сачуван"
 #: src/formhist/dialogs.c:174
 msgid ""
 "No saved information for this URL.\n"
-"If you want to save passwords for this URL, enable it by pressing the "
-"\"Toggle saving\" button."
+"If you want to save passwords for this URL, enable it by pressing the \"Toggle saving\" button."
 msgstr ""
 "Нема сачуваних података за овај УРЛ.\n"
-"Уколико желите да чувате лозинке за овај УРЛ, активирајте то притиском на "
-"дугме „Смени чување“."
+"Уколико желите да чувате лозинке за овај УРЛ, активирајте то притиском на дугме „Смени чување“."
 
 #. accelerator_context(src/formhist/dialogs.c:formhist_buttons)
 #: src/formhist/dialogs.c:209
@@ -6383,13 +5734,8 @@ msgid "Show form history dialog"
 msgstr "Приказивање дијалога историје образаца"
 
 #: src/formhist/formhist.c:38
-msgid ""
-"Ask if a login form should be saved to file or not. This option only "
-"disables the dialog, already saved login forms are unaffected."
-msgstr ""
-"Питати да ли да се образац за пријављивање чува у датотеку или не. Ова "
-"опција само деактивира дијалог, то неће имати утицаја на обрасце за "
-"пријављивање који су већ сачувани."
+msgid "Ask if a login form should be saved to file or not. This option only disables the dialog, already saved login forms are unaffected."
+msgstr "Питати да ли да се образац за пријављивање чува у датотеку или не. Ова опција само деактивира дијалог, то неће имати утицаја на обрасце за пријављивање који су већ сачувани."
 
 #: src/formhist/formhist.c:426
 msgid "Form history"
@@ -6399,15 +5745,13 @@ msgstr "Историја образаца"
 msgid ""
 "Should this login be remembered?\n"
 "\n"
-"Please note that the password will be stored obscured (but unencrypted) in a "
-"file on your disk.\n"
+"Please note that the password will be stored obscured (but unencrypted) in a file on your disk.\n"
 "\n"
 "If you are using a valuable password, answer NO."
 msgstr ""
 "Запамтити ово пријављивање?\n"
 "\n"
-"Имајте у виду да ће лозинка бити ускладиштена у прикривеном (али не и "
-"шифрованом) облику у датотеку на вашем диску.\n"
+"Имајте у виду да ће лозинка бити ускладиштена у прикривеном (али не и шифрованом) облику у датотеку на вашем диску.\n"
 "\n"
 "Уколико је лозинка важна, одговорите са НЕ."
 
@@ -6517,139 +5861,139 @@ msgstr "Глобална историја"
 
 #: src/intl/gettext/libintl.c:27 src/intl/libintl.c:27
 msgid "System"
-msgstr "системски"
+msgstr "Системски"
 
 #: src/intl/gettext/libintl.c:28 src/intl/libintl.c:28
 msgid "English"
-msgstr "енглески"
+msgstr "Енглески"
 
 #: src/intl/gettext/libintl.c:30 src/intl/libintl.c:30
 msgid "Afrikaans"
-msgstr "африканс"
+msgstr "Африканс"
 
 #: src/intl/gettext/libintl.c:31 src/intl/libintl.c:31
 msgid "Belarusian"
-msgstr "белоруски"
+msgstr "Белоруски"
 
 #: src/intl/gettext/libintl.c:32 src/intl/libintl.c:32
 msgid "Brazilian Portuguese"
-msgstr "бразилски португалски"
+msgstr "Бразилски португалски"
 
 #: src/intl/gettext/libintl.c:33 src/intl/libintl.c:33
 msgid "Bulgarian"
-msgstr "бугарски"
+msgstr "Бугарски"
 
 #: src/intl/gettext/libintl.c:34 src/intl/libintl.c:34
 msgid "Catalan"
-msgstr "каталонски"
+msgstr "Каталонски"
 
 #: src/intl/gettext/libintl.c:35 src/intl/libintl.c:35
 msgid "Croatian"
-msgstr "хрватски"
+msgstr "Хрватски"
 
 #: src/intl/gettext/libintl.c:36 src/intl/libintl.c:36
 msgid "Czech"
-msgstr "чешки"
+msgstr "Чешки"
 
 #: src/intl/gettext/libintl.c:37 src/intl/libintl.c:37
 msgid "Danish"
-msgstr "дански"
+msgstr "Дански"
 
 #: src/intl/gettext/libintl.c:38 src/intl/libintl.c:38
 msgid "Dutch"
-msgstr "холандски"
+msgstr "Холандски"
 
 #: src/intl/gettext/libintl.c:39 src/intl/libintl.c:39
 msgid "Estonian"
-msgstr "естонски"
+msgstr "Естонски"
 
 #: src/intl/gettext/libintl.c:40 src/intl/libintl.c:40
 msgid "Finnish"
-msgstr "фински"
+msgstr "Фински"
 
 #: src/intl/gettext/libintl.c:41 src/intl/libintl.c:41
 msgid "French"
-msgstr "француски"
+msgstr "Француски"
 
 #: src/intl/gettext/libintl.c:42 src/intl/libintl.c:42
 msgid "Galician"
-msgstr "галицијски"
+msgstr "Галицијски"
 
 #: src/intl/gettext/libintl.c:43 src/intl/libintl.c:43
 msgid "German"
-msgstr "немачки"
+msgstr "Немачки"
 
 #: src/intl/gettext/libintl.c:44 src/intl/libintl.c:44
 msgid "Greek"
-msgstr "грчки"
+msgstr "Грчки"
 
 #: src/intl/gettext/libintl.c:45 src/intl/libintl.c:45
 msgid "Hungarian"
-msgstr "мађарски"
+msgstr "Мађарски"
 
 #: src/intl/gettext/libintl.c:46 src/intl/libintl.c:46
 msgid "Icelandic"
-msgstr "исландски"
+msgstr "Исландски"
 
 #: src/intl/gettext/libintl.c:47 src/intl/libintl.c:47
 msgid "Indonesian"
-msgstr "индонежански"
+msgstr "Индонежански"
 
 #: src/intl/gettext/libintl.c:48 src/intl/libintl.c:48
 msgid "Italian"
-msgstr "италијански"
+msgstr "Италијански"
 
 #: src/intl/gettext/libintl.c:49 src/intl/libintl.c:49
 msgid "Japanese"
-msgstr "јапански"
+msgstr "Јапански"
 
 #: src/intl/gettext/libintl.c:50 src/intl/libintl.c:50
 msgid "Lithuanian"
-msgstr "литвански"
+msgstr "Литвански"
 
 #: src/intl/gettext/libintl.c:51 src/intl/libintl.c:51
 msgid "Norwegian"
-msgstr "норвешки"
+msgstr "Норвешки"
 
 #: src/intl/gettext/libintl.c:52 src/intl/libintl.c:52
 msgid "Polish"
-msgstr "пољски"
+msgstr "Пољски"
 
 #: src/intl/gettext/libintl.c:53 src/intl/libintl.c:53
 msgid "Portuguese"
-msgstr "португалски"
+msgstr "Португалски"
 
 #: src/intl/gettext/libintl.c:54 src/intl/libintl.c:54
 msgid "Romanian"
-msgstr "румунски"
+msgstr "Румунски"
 
 #: src/intl/gettext/libintl.c:55 src/intl/libintl.c:55
 msgid "Russian"
-msgstr "руски"
+msgstr "Руски"
 
 #: src/intl/gettext/libintl.c:56 src/intl/libintl.c:56
 msgid "Serbian"
-msgstr "српски"
+msgstr "Српски"
 
 #: src/intl/gettext/libintl.c:57 src/intl/libintl.c:57
 msgid "Slovak"
-msgstr "словачки"
+msgstr "Словачки"
 
 #: src/intl/gettext/libintl.c:58 src/intl/libintl.c:58
 msgid "Spanish"
-msgstr "шпански"
+msgstr "Шпански"
 
 #: src/intl/gettext/libintl.c:59 src/intl/libintl.c:59
 msgid "Swedish"
-msgstr "шведски"
+msgstr "Шведски"
 
 #: src/intl/gettext/libintl.c:60 src/intl/libintl.c:60
 msgid "Turkish"
-msgstr "турски"
+msgstr "Турски"
 
 #: src/intl/gettext/libintl.c:61 src/intl/libintl.c:61
 msgid "Ukrainian"
-msgstr "украјински"
+msgstr "Украјински"
 
 #: src/main/interlink.c:330 src/main/select.c:561
 #, c-format
@@ -6759,52 +6103,24 @@ msgid "MIME type associations"
 msgstr "Придружења MIME типова"
 
 #: src/mime/backend/default.c:27
-msgid ""
-"Handler <-> MIME type association. The first sub-tree is the MIME class "
-"while the second sub-tree is the MIME type (ie. image/gif handler will "
-"reside at mime.type.image.gif). Each MIME type option should contain (case-"
-"sensitive) name of the MIME handler (its properties are stored at mime."
-"handler.<name>)."
-msgstr ""
-"Придружења руковалац <-> MIME тип. Прво подстабло је класа MIME-а, а друго "
-"MIME тип (нпр. руковалац врстом image/gif ће се налазити у mime.type.image."
-"gif). Свака опција MIME типа би требало да садржи назив (уз обраћање пажње "
-"на велика и мала слова) руковаоца MIME-а (његове особине се чувају у mime."
-"handler.<назив>)."
+msgid "Handler <-> MIME type association. The first sub-tree is the MIME class while the second sub-tree is the MIME type (ie. image/gif handler will reside at mime.type.image.gif). Each MIME type option should contain (case-sensitive) name of the MIME handler (its properties are stored at mime.handler.<name>)."
+msgstr "Придружења руковалац <-> MIME тип. Прво подстабло је класа MIME-а, а друго MIME тип (нпр. руковалац врстом image/gif ће се налазити у mime.type.image.gif). Свака опција MIME типа би требало да садржи назив (уз обраћање пажње на велика и мала слова) руковаоца MIME-а (његове особине се чувају у mime.handler.<назив>)."
 
 #: src/mime/backend/default.c:36
-msgid ""
-"Handler matching this MIME-type class ('*' is used here in place of '.')."
-msgstr ""
-"Руковалац који одговара овој класи MIME типа („*“ се овде користи уместо "
-"„.“)."
+msgid "Handler matching this MIME-type class ('*' is used here in place of '.')."
+msgstr "Руковалац који одговара овој класи MIME типа („*“ се овде користи уместо „.“)."
 
 #: src/mime/backend/default.c:41
-msgid ""
-"Handler matching this MIME-type name ('*' is used here in place of '.')."
-msgstr ""
-"Руковалац који одговара овом називу MIME типа („*“ се користи уместо „.“)."
+msgid "Handler matching this MIME-type name ('*' is used here in place of '.')."
+msgstr "Руковалац који одговара овом називу MIME типа („*“ се користи уместо „.“)."
 
 #: src/mime/backend/default.c:45
 msgid "File type handlers"
 msgstr "Руковаоци врстама датотека"
 
 #: src/mime/backend/default.c:47
-msgid ""
-"A file type handler is a set of information about how to use an external "
-"program to view a file. It is possible to refer to it for several MIME types "
-"-- e.g., you can define an 'image' handler to which mime.type.image.png, "
-"mime.type.image.jpeg, and so on will refer; or one might define a handler "
-"for a more specific type of file -- e.g., PDF files. Note you must define "
-"both a MIME handler and a MIME type association for it to work."
-msgstr ""
-"Руковалац врстом датотека је скуп информација о томе како користити спољашњи "
-"програм да би се прегледала датотека. Могуће је да се исти програм позива за "
-"неколико MIME типова: нпр. можете да задате руковалац „image“ (слика), на "
-"кога ће се позивати mime.type.image.png, mime.type.image.jpeg, итд. Или, "
-"уместо тога бисте могли да задате руковаоце за посебне врсте датотека — нпр. "
-"за PDF датотеке. Имајте у виду да морате задати и руковалац MIME-а и "
-"придружење MIME типа да би ово функционисало."
+msgid "A file type handler is a set of information about how to use an external program to view a file. It is possible to refer to it for several MIME types -- e.g., you can define an 'image' handler to which mime.type.image.png, mime.type.image.jpeg, and so on will refer; or one might define a handler for a more specific type of file -- e.g., PDF files. Note you must define both a MIME handler and a MIME type association for it to work."
+msgstr "Руковалац врстом датотека је скуп информација о томе како користити спољашњи програм да би се прегледала датотека. Могуће је да се исти програм позива за неколико MIME типова: нпр. можете да задате руковалац „image“ (слика), на кога ће се позивати mime.type.image.png, mime.type.image.jpeg, итд. Или, уместо тога бисте могли да задате руковаоце за посебне врсте датотека — нпр. за PDF датотеке. Имајте у виду да морате задати и руковалац MIME-а и придружење MIME типа да би ово функционисало."
 
 #: src/mime/backend/default.c:58
 msgid "Description of this handler."
@@ -6812,8 +6128,7 @@ msgstr "Опис овог руковаоца."
 
 #: src/mime/backend/default.c:62
 msgid "System-specific handler description (ie. unix, unix-xwin, ...)."
-msgstr ""
-"Опис руковаоца својствен одређеном систему (нпр. unix, unix-xwin, ...)."
+msgstr "Опис руковаоца својствен одређеном систему (нпр. unix, unix-xwin, ...)."
 
 #: src/mime/backend/default.c:65 src/mime/backend/mailcap.c:102
 msgid "Ask before opening"
@@ -6837,14 +6152,8 @@ msgstr "Програм"
 
 #: src/mime/backend/default.c:76
 #, no-c-format
-msgid ""
-"External viewer for this file type. '%f' in this string will be substituted "
-"by a file name, '%u' by its uri. Do _not_ put single- or double-quotes "
-"around the % sign."
-msgstr ""
-"Спољашњи прегледач за ову врсту датотека. „%f“ у овој нисци ће бити замењено "
-"називом датотеке, „%u“ њеним УРИ-јем. Не окружујте знак % апострофима или "
-"наводницима."
+msgid "External viewer for this file type. '%f' in this string will be substituted by a file name, '%u' by its uri. Do _not_ put single- or double-quotes around the % sign."
+msgstr "Спољашњи прегледач за ову врсту датотека. „%f“ у овој нисци ће бити замењено називом датотеке, „%u“ њеним УРИ-јем. Не окружујте знак % апострофима или наводницима."
 
 #: src/mime/backend/default.c:82
 msgid "File extension associations"
@@ -6855,10 +6164,8 @@ msgid "Extension <-> MIME type association."
 msgstr "Придружења наставак <-> MIME тип."
 
 #: src/mime/backend/default.c:88
-msgid ""
-"MIME-type matching this file extension ('*' is used here in place of '.')."
-msgstr ""
-"MIME тип који одговара овом наставку датотеке („*“ се користи уместо „.“)."
+msgid "MIME-type matching this file extension ('*' is used here in place of '.')."
+msgstr "MIME тип који одговара овом наставку датотеке („*“ се користи уместо „.“)."
 
 #. name:
 #: src/mime/backend/default.c:221
@@ -6880,13 +6187,8 @@ msgid "Enable mailcap support."
 msgstr "Активира подршку за mailcap."
 
 #: src/mime/backend/mailcap.c:99
-msgid ""
-"Mailcap search path. Colon-separated list of files. Leave as \"\" to use "
-"MAILCAP environment variable instead."
-msgstr ""
-"Путања претраге за mailcap. Ово је листа датотека раздвојених двотачкама. "
-"Оставите као „“ (празно) да би се користила вредност променљиве окружења "
-"MAILCAP."
+msgid "Mailcap search path. Colon-separated list of files. Leave as \"\" to use MAILCAP environment variable instead."
+msgstr "Путања претраге за mailcap. Ово је листа датотека раздвојених двотачкама. Оставите као „“ (празно) да би се користила вредност променљиве окружења MAILCAP."
 
 #: src/mime/backend/mailcap.c:104
 msgid "Ask before using the handlers defined by mailcap."
@@ -6915,14 +6217,8 @@ msgid "Prioritize entries by file"
 msgstr "Постављање приоритета према датотеци"
 
 #: src/mime/backend/mailcap.c:117
-msgid ""
-"Prioritize entries by the order of the files in the mailcap path. This means "
-"that wildcard entries (like: image/*) will also be checked before deciding "
-"the handler."
-msgstr ""
-"Постављање приоритете према редоследу датотека у путањи mailcap-а. Ово значи "
-"да ће и ставке са џокерским знацима (нпр: image/*) бити такође провераване "
-"пре бирања руковаоца."
+msgid "Prioritize entries by the order of the files in the mailcap path. This means that wildcard entries (like: image/*) will also be checked before deciding the handler."
+msgstr "Постављање приоритете према редоследу датотека у путањи mailcap-а. Ово значи да ће и ставке са џокерским знацима (нпр: image/*) бити такође провераване пре бирања руковаоца."
 
 #: src/mime/backend/mailcap.c:357
 #, c-format
@@ -6935,13 +6231,8 @@ msgid "Mimetypes files"
 msgstr "Датотеке „mimetypes“"
 
 #: src/mime/backend/mimetypes.c:48
-msgid ""
-"Options for the support of mime.types files. These files can be used to find "
-"the content type of a URL by looking at the extension of the file name."
-msgstr ""
-"Опције подршке за датотеке mime.types. Ове датотеке се могу користити за "
-"проналажење врсте садржаја било ког УРЛ-а посматрањем наставка назива "
-"датотеке."
+msgid "Options for the support of mime.types files. These files can be used to find the content type of a URL by looking at the extension of the file name."
+msgstr "Опције подршке за датотеке mime.types. Ове датотеке се могу користити за проналажење врсте садржаја било ког УРЛ-а посматрањем наставка назива датотеке."
 
 #: src/mime/backend/mimetypes.c:54
 msgid "Enable mime.types support."
@@ -6949,9 +6240,7 @@ msgstr "Активирање подршке за mime.types."
 
 #: src/mime/backend/mimetypes.c:58
 msgid "The search path for mime.types files. Colon-separated list of files."
-msgstr ""
-"Путања претраге за датотеке mime.types. Листа датотека раздвојених "
-"двотачкама."
+msgstr "Путања претраге за датотеке mime.types. Листа датотека раздвојених двотачкама."
 
 #: src/mime/dialogs.c:66
 msgid "Delete extension"
@@ -6992,24 +6281,16 @@ msgid "Default MIME-type"
 msgstr "Подразумевани MIME тип"
 
 #: src/mime/mime.c:44
-msgid ""
-"Document MIME-type to assume by default (when we are unable to guess it "
-"properly from known information about the document)."
-msgstr ""
-"Претпостављени MIME тип (када нисмо у могућности да га прописно погодимо из "
-"познатих података о документу)."
+msgid "Document MIME-type to assume by default (when we are unable to guess it properly from known information about the document)."
+msgstr "Претпостављени MIME тип (када нисмо у могућности да га прописно погодимо из познатих података о документу)."
 
 #: src/network/ssl/ssl.c:114 src/network/ssl/ssl.c:244
 msgid "Verify certificates"
 msgstr "Верификовање сертификата"
 
 #: src/network/ssl/ssl.c:116
-msgid ""
-"Verify the peer's SSL certificate. Note that this needs extensive "
-"configuration of OpenSSL by the user."
-msgstr ""
-"Верификовање сертификата SSL-а. Имајте у виду да ово захтева знатно "
-"подешавање OpenSSL-а од стране корисника."
+msgid "Verify the peer's SSL certificate. Note that this needs extensive configuration of OpenSSL by the user."
+msgstr "Верификовање сертификата SSL-а. Имајте у виду да ово захтева знатно подешавање OpenSSL-а од стране корисника."
 
 #: src/network/ssl/ssl.c:119 src/network/ssl/ssl.c:249
 msgid "Use HTTPS by default"
@@ -7028,12 +6309,8 @@ msgid "X509 client certificate options."
 msgstr "Опције X509 клијентског сертификата."
 
 #: src/network/ssl/ssl.c:129 src/network/ssl/ssl.c:282
-msgid ""
-"Enable or not the sending of X509 client certificates to servers which "
-"request them."
-msgstr ""
-"Активирање или деактивирање слања X509 клијентских сертификата серверима "
-"који их траже."
+msgid "Enable or not the sending of X509 client certificates to servers which request them."
+msgstr "Активирање или деактивирање слања X509 клијентских сертификата серверима који их траже."
 
 #: src/network/ssl/ssl.c:133
 msgid "Certificate nickname"
@@ -7041,47 +6318,29 @@ msgstr "Надимак сертификата"
 
 #: src/network/ssl/ssl.c:135
 msgid ""
-"The nickname of the client certificate stored in NSS database. If this value "
-"is unset, the nickname from the X509_CLIENT_CERT variable is used instead. "
-"If you have a PKCS#12 file containing client certificate, you can import it "
-"into your NSS database with:\n"
+"The nickname of the client certificate stored in NSS database. If this value is unset, the nickname from the X509_CLIENT_CERT variable is used instead. If you have a PKCS#12 file containing client certificate, you can import it into your NSS database with:\n"
 "\n"
 "$ pk12util -i mycert.p12 -d /path/to/database\n"
 "\n"
-"The NSS database location can be changed by SSL_DIR environment variable. "
-"The database can be also shared with Mozilla browsers."
+"The NSS database location can be changed by SSL_DIR environment variable. The database can be also shared with Mozilla browsers."
 msgstr ""
-"Надимак клијентског сертификата ускладиштеног у NSS бази. Ако ова вредност "
-"није постављена, биће коришћен надимак из променљиве X509_CLIENT_CERT. Ако "
-"имате PKCS#12 датотеку која садржи клијентски сертификат, можете је увести у "
-"вашу NSS базу наредбом:\n"
+"Надимак клијентског сертификата ускладиштеног у NSS бази. Ако ова вредност није постављена, биће коришћен надимак из променљиве X509_CLIENT_CERT. Ако имате PKCS#12 датотеку која садржи клијентски сертификат, можете је увести у вашу NSS базу наредбом:\n"
 "\n"
 "$ pk12util -i mycert.p12 -d /putanja/do/baze\n"
 "\n"
-"Локација NSS базе се може променити променљивом окружења SSL_DIR. База се "
-"може делити и са Mozilla читачима."
+"Локација NSS базе се може променити променљивом окружења SSL_DIR. База се може делити и са Mozilla читачима."
 
 #: src/network/ssl/ssl.c:147 src/network/ssl/ssl.c:285
 msgid "Certificate File"
 msgstr "Датотека са сертификатима"
 
 #: src/network/ssl/ssl.c:149 src/network/ssl/ssl.c:287
-msgid ""
-"The location of a file containing the client certificate and unencrypted "
-"private key in PEM format. If unset, the file pointed to by the "
-"X509_CLIENT_CERT variable is used instead."
-msgstr ""
-"Локација датотеке која садржи клијентски сертификат и нешифровани приватни "
-"кључ у формату PEM. Уколико се искључи, уместо тога ће се користити датотека "
-"на коју показује променљива X509_CLIENT_CERT."
+msgid "The location of a file containing the client certificate and unencrypted private key in PEM format. If unset, the file pointed to by the X509_CLIENT_CERT variable is used instead."
+msgstr "Локација датотеке која садржи клијентски сертификат и нешифровани приватни кључ у формату PEM. Уколико се искључи, уместо тога ће се користити датотека на коју показује променљива X509_CLIENT_CERT."
 
 #: src/network/ssl/ssl.c:246
-msgid ""
-"Verify the peer's SSL certificate.  If you enable this, set also \"Trusted "
-"CA file\"."
-msgstr ""
-"Верификација сертификата SSL-а. Ако ово активирате, поставите и „датотеку ИС "
-"(CA) са поверењем“."
+msgid "Verify the peer's SSL certificate.  If you enable this, set also \"Trusted CA file\"."
+msgstr "Верификација сертификата SSL-а. Ако ово активирате, поставите и „датотеку ИС (CA) са поверењем“."
 
 #. The default value of the following option points to a file
 #. * generated by the ca-certificates Debian package.  Don't use
@@ -7097,19 +6356,13 @@ msgstr "Датотека ИС (CA) са поверењем"
 
 #: src/network/ssl/ssl.c:268
 msgid ""
-"The location of a file containing certificates of trusted certification "
-"authorities in PEM format. ELinks then trusts certificates issued by these "
-"CAs.\n"
+"The location of a file containing certificates of trusted certification authorities in PEM format. ELinks then trusts certificates issued by these CAs.\n"
 "\n"
-"If you change this option or the file, you must restart ELinks for the "
-"changes to take effect. This option affects GnuTLS but not OpenSSL."
+"If you change this option or the file, you must restart ELinks for the changes to take effect. This option affects GnuTLS but not OpenSSL."
 msgstr ""
-"Локација датотеке која садржи сертификате издавача сертификата са поверењем "
-"у формату PEM. ELinks ће онда указати поверење сертификатима које су издали "
-"ти ИС.\n"
+"Локација датотеке која садржи сертификате издавача сертификата са поверењем у формату PEM. ELinks ће онда указати поверење сертификатима које су издали ти ИС.\n"
 "\n"
-"Ако промените ову опцију или датотеку, морате поново покренути ELinks да би "
-"измене ступиле на снагу. Ова опција утиче на GnuTLS, али не и на OpenSSL."
+"Ако промените ову опцију или датотеку, морате поново покренути ELinks да би измене ступиле на снагу. Ова опција утиче на GnuTLS, али не и на OpenSSL."
 
 #. name:
 #: src/network/ssl/ssl.c:308 src/network/ssl/ssl.c:325
@@ -7316,7 +6569,7 @@ msgstr "Ова верзија ELinks-а не садржи подршку за SS
 
 #: src/network/state.c:95
 msgid "JavaScript support is not enabled"
-msgstr "Подршка за JavaScript није активирана."
+msgstr "Подршка за JavaScript није активирана"
 
 #: src/network/state.c:98
 msgid "Bad NNTP response"
@@ -7584,81 +6837,48 @@ msgid "Use compact tracker format"
 msgstr "Коришћење компактног формата трекера"
 
 #: src/protocol/bittorrent/bittorrent.c:57
-msgid ""
-"Whether to request that the tracker returns peer info in compact format. "
-"Note, the compact format only supports IPv4 addresses."
-msgstr ""
-"Да ли да се захтева да трекер враћа информације о суседима у компактном "
-"формату. Приметите да компактни формат подржава само IPv4 адресе."
+msgid "Whether to request that the tracker returns peer info in compact format. Note, the compact format only supports IPv4 addresses."
+msgstr "Да ли да се захтева да трекер враћа информације о суседима у компактном формату. Приметите да компактни формат подржава само IPv4 адресе."
 
 #: src/protocol/bittorrent/bittorrent.c:61
 msgid "Tracker announce interval"
 msgstr "Интервал најаве трекеру"
 
 #: src/protocol/bittorrent/bittorrent.c:63
-msgid ""
-"The number of seconds to wait between periodically contacting the tracker "
-"for announcing progress and requesting more peers. Set to zero to use the "
-"interval requested by the tracker."
-msgstr ""
-"Број секунди између повременог обраћања трекеру ради објављивања прогреса и "
-"захтевања још суседа. Поставите на нулу да бисте користили интервал који "
-"захтева трекер."
+msgid "The number of seconds to wait between periodically contacting the tracker for announcing progress and requesting more peers. Set to zero to use the interval requested by the tracker."
+msgstr "Број секунди између повременог обраћања трекеру ради објављивања прогреса и захтевања још суседа. Поставите на нулу да бисте користили интервал који захтева трекер."
 
 #: src/protocol/bittorrent/bittorrent.c:68
 msgid "IP-address to announce"
 msgstr "IP адреса која се најављује"
 
 #: src/protocol/bittorrent/bittorrent.c:70
-msgid ""
-"What IP address to report to the tracker. If set to \"\" no IP address will "
-"be sent and the tracker will automatically determine an appropriate IP "
-"address."
-msgstr ""
-"Која IP адреса се пријављује трекеру. Ако се подеси на „“ (празно), неће се "
-"слати IP адреса, па ће је трекер аутоматски одредити."
+msgid "What IP address to report to the tracker. If set to \"\" no IP address will be sent and the tracker will automatically determine an appropriate IP address."
+msgstr "Која IP адреса се пријављује трекеру. Ако се подеси на „“ (празно), неће се слати IP адреса, па ће је трекер аутоматски одредити."
 
 #: src/protocol/bittorrent/bittorrent.c:74
 msgid "User identification string"
 msgstr "Ниска идентификације корисника"
 
 #: src/protocol/bittorrent/bittorrent.c:76
-msgid ""
-"An additional identification that is not shared with any users. It is "
-"intended to allow a client to prove their identity should their IP address "
-"change. It is an optional parameter, but some trackers require this "
-"parameter. If set to \"\" no user key will be sent to the tracker."
-msgstr ""
-"Додатна идентификација која се не дели ни са једним корисником. Намењена је "
-"доказивању идентитета од стране клијента у случају да му се IP адреса "
-"промени. Ово је опциони параметар, али га неки трекери захтевају. Ако се "
-"подеси на „“ (празно), кориснички кључ се неће слати трекеру."
+msgid "An additional identification that is not shared with any users. It is intended to allow a client to prove their identity should their IP address change. It is an optional parameter, but some trackers require this parameter. If set to \"\" no user key will be sent to the tracker."
+msgstr "Додатна идентификација која се не дели ни са једним корисником. Намењена је доказивању идентитета од стране клијента у случају да му се IP адреса промени. Ово је опциони параметар, али га неки трекери захтевају. Ако се подеси на „“ (празно), кориснички кључ се неће слати трекеру."
 
 #: src/protocol/bittorrent/bittorrent.c:82
 msgid "Maximum number of peers to request"
 msgstr "Максималан број суседа који се захтева"
 
 #: src/protocol/bittorrent/bittorrent.c:84
-msgid ""
-"The maximum number of peers to request from the tracker. Set to 0 to use the "
-"server default."
-msgstr ""
-"Максималан број суседа који се захтева од трекера. Поставите на 0 да "
-"користите подразумевану вредност сервера."
+msgid "The maximum number of peers to request from the tracker. Set to 0 to use the server default."
+msgstr "Максималан број суседа који се захтева од трекера. Поставите на 0 да користите подразумевану вредност сервера."
 
 #: src/protocol/bittorrent/bittorrent.c:87
 msgid "Minimum peers to skip rerequesting"
 msgstr "Минималан број суседа за прескакање поновног захтевања"
 
 #: src/protocol/bittorrent/bittorrent.c:89
-msgid ""
-"The minimum number of peers to have in the current peer info pool before "
-"skipping requesting of more peers. I.e. setting numwant to zero. Set to 0 to "
-"not have any limit."
-msgstr ""
-"Минималан број суседа у текућем резервоару пре престанка захтевања још "
-"суседа, тј. постављања numwant на нулу. Поставите на 0 да искључите "
-"ограничење."
+msgid "The minimum number of peers to have in the current peer info pool before skipping requesting of more peers. I.e. setting numwant to zero. Set to 0 to not have any limit."
+msgstr "Минималан број суседа у текућем резервоару пре престанка захтевања још суседа, тј. постављања numwant на нулу. Поставите на 0 да искључите ограничење."
 
 #. ******************************************************************
 #. Lowlevel peer-wire options:
@@ -7676,68 +6896,40 @@ msgid "Maximum number of peer connections"
 msgstr "Максималан број суседских повезивања"
 
 #: src/protocol/bittorrent/bittorrent.c:104
-msgid ""
-"The maximum number of allowed connections to both active and non-active "
-"peers. By increasing the number of allowed connections, the chance of "
-"finding good peers to download from is increased. However, too many "
-"connections can lead to TCP congestion. If the maximum is reached all new "
-"incoming connections will be closed."
-msgstr ""
-"Максималан број дозвољених повезивања са активним и неактивним суседима. "
-"Повећањем броја дозвољених повезивања увећавају се шансе за налажење добрих "
-"суседа за преузимање. Међутим, превише повезивања може довести до загушења "
-"TCP-ја. Ако се достигне максимум, сва нова долазећа повезивања ће бити "
-"затворена."
+msgid "The maximum number of allowed connections to both active and non-active peers. By increasing the number of allowed connections, the chance of finding good peers to download from is increased. However, too many connections can lead to TCP congestion. If the maximum is reached all new incoming connections will be closed."
+msgstr "Максималан број дозвољених повезивања са активним и неактивним суседима. Повећањем броја дозвољених повезивања увећавају се шансе за налажење добрих суседа за преузимање. Међутим, превише повезивања може довести до загушења TCP-ја. Ако се достигне максимум, сва нова долазећа повезивања ће бити затворена."
 
 #: src/protocol/bittorrent/bittorrent.c:111
 msgid "Maximum peer message length"
 msgstr "Максимална дужина поруке суседа"
 
 #: src/protocol/bittorrent/bittorrent.c:113
-msgid ""
-"The maximum length of messages to accept over the wire. Larger values will "
-"cause the connection to be dropped."
-msgstr ""
-"Максимална дужина порука прихваћених преко жице. Веће вредности "
-"проузроковаће пад повезивања."
+msgid "The maximum length of messages to accept over the wire. Larger values will cause the connection to be dropped."
+msgstr "Максимална дужина порука прихваћених преко жице. Веће вредности проузроковаће пад повезивања."
 
 #: src/protocol/bittorrent/bittorrent.c:116
 msgid "Maximum allowed request length"
 msgstr "Максимална дозвољена дужина захтева"
 
 #: src/protocol/bittorrent/bittorrent.c:118
-msgid ""
-"The maximum length to allow for incoming requests. Larger requests will "
-"cause the connection to be dropped."
-msgstr ""
-"Максимална дозвољена дужина долазећих захтева. Већи захтеви проузроковаће "
-"пад повезивања."
+msgid "The maximum length to allow for incoming requests. Larger requests will cause the connection to be dropped."
+msgstr "Максимална дозвољена дужина долазећих захтева. Већи захтеви проузроковаће пад повезивања."
 
 #: src/protocol/bittorrent/bittorrent.c:121
 msgid "Length of requests"
 msgstr "Дужина захтева"
 
 #: src/protocol/bittorrent/bittorrent.c:123
-msgid ""
-"How many bytes to query for per request. This is complementary to the "
-"max_request_length option. If the configured length is bigger than the piece "
-"length it will be truncated."
-msgstr ""
-"Колико бајтова се испитује по захтеву. Ово је комплементарно са опцијом "
-"max_request_length. Биће скраћено ако је подешена дужина већа од величине "
-"парчета."
+msgid "How many bytes to query for per request. This is complementary to the max_request_length option. If the configured length is bigger than the piece length it will be truncated."
+msgstr "Колико бајтова се испитује по захтеву. Ово је комплементарно са опцијом max_request_length. Биће скраћено ако је подешена дужина већа од величине парчета."
 
 #: src/protocol/bittorrent/bittorrent.c:128
 msgid "Peer inactivity timeout"
 msgstr "Тајмаут код неактивности суседа"
 
 #: src/protocol/bittorrent/bittorrent.c:130
-msgid ""
-"The number of seconds to wait before closing a socket on which nothing has "
-"been received or sent."
-msgstr ""
-"Број секунди који се чека пре затварања утичнице преко које ништа није "
-"примљено нити послато."
+msgid "The number of seconds to wait before closing a socket on which nothing has been received or sent."
+msgstr "Број секунди који се чека пре затварања утичнице преко које ништа није примљено нити послато."
 
 #: src/protocol/bittorrent/bittorrent.c:133
 msgid "Maximum peer pool size"
@@ -7745,13 +6937,11 @@ msgstr "Максимална величина резервоара суседа"
 
 #: src/protocol/bittorrent/bittorrent.c:135
 msgid ""
-"Maximum number of items in the peer pool. The peer pool contains information "
-"used for establishing connections to new peers.\n"
+"Maximum number of items in the peer pool. The peer pool contains information used for establishing connections to new peers.\n"
 "\n"
 "Set to 0 to have unlimited size."
 msgstr ""
-"Максималан број ставки резервоара суседа. Резервоар суседа садржи "
-"информације које се користе за успостављање повезивања са новим суседима.\n"
+"Максималан број ставки резервоара суседа. Резервоар суседа садржи информације које се користе за успостављање повезивања са новим суседима.\n"
 "\n"
 "Поставите на 0 за неограничену величину."
 
@@ -7778,18 +6968,8 @@ msgid "Sharing rate"
 msgstr "Проток дељења"
 
 #: src/protocol/bittorrent/bittorrent.c:160
-msgid ""
-"The minimum sharing rate to achieve before stop seeding. The sharing rate is "
-"computed as the number of uploaded bytes divided with the number of "
-"downloaded bytes. The value should be a double value between 0.0 and 1.0 "
-"both included. Set to 1.0 to atleast upload a complete copy of all data and "
-"set to 0.0 to have unlimited sharing rate."
-msgstr ""
-"Минималан проток дељења након кога се престаје са сидовањем. Проток дељења "
-"се рачуна као број послатих бајтова подељен са бројем преузетих бајтова. "
-"Вредност би требало да је децимални број између 0.0 и 1.0, укључујући обе "
-"вредности. Поставите на 1.0 да бисте макар послали цео примерак свих "
-"података, а на 0.0 за неограничен проток слања."
+msgid "The minimum sharing rate to achieve before stop seeding. The sharing rate is computed as the number of uploaded bytes divided with the number of downloaded bytes. The value should be a double value between 0.0 and 1.0 both included. Set to 1.0 to atleast upload a complete copy of all data and set to 0.0 to have unlimited sharing rate."
+msgstr "Минималан проток дељења након кога се престаје са сидовањем. Проток дељења се рачуна као број послатих бајтова подељен са бројем преузетих бајтова. Вредност би требало да је децимални број између 0.0 и 1.0, укључујући обе вредности. Поставите на 1.0 да бисте макар послали цео примерак свих података, а на 0.0 за неограничен проток слања."
 
 #: src/protocol/bittorrent/bittorrent.c:167
 msgid "Maximum number of uploads"
@@ -7805,9 +6985,7 @@ msgid "Minimum number of uploads"
 msgstr "Минималан број слања"
 
 #: src/protocol/bittorrent/bittorrent.c:174
-msgid ""
-"The minimum number of uploads which should at least be used for new "
-"connections."
+msgid "The minimum number of uploads which should at least be used for new connections."
 msgstr "Минималан број слања који би требало да се користи за нова повезивања."
 
 #: src/protocol/bittorrent/bittorrent.c:178
@@ -7823,18 +7001,8 @@ msgid "Number of pending requests"
 msgstr "Број захтева на чекању"
 
 #: src/protocol/bittorrent/bittorrent.c:185
-msgid ""
-"How many piece requests to continuously keep in queue. Pipelining of "
-"requests is essential to saturate connections and get a good connection "
-"performance and thus a faster download. However, a very big queue size can "
-"lead to wasting bandwidth near the end of the connection since remaining "
-"piece blocks will be requested from multiple peers."
-msgstr ""
-"Број захтева за парчићима које треба држати у реду у сваком тренутку. Ређање "
-"захтева је кључно за засићење повезивања и њихове добре перформансе и самим "
-"тим брже преузимање. Међутим, веома велика дужина реда може довести до "
-"траћења протока при крају повезивања, зато што ће се преостали блокови "
-"парчића захтевати од више суседа."
+msgid "How many piece requests to continuously keep in queue. Pipelining of requests is essential to saturate connections and get a good connection performance and thus a faster download. However, a very big queue size can lead to wasting bandwidth near the end of the connection since remaining piece blocks will be requested from multiple peers."
+msgstr "Број захтева за парчићима које треба држати у реду у сваком тренутку. Ређање захтева је кључно за засићење повезивања и њихове добре перформансе и самим тим брже преузимање. Међутим, веома велика дужина реда може довести до траћења протока при крају повезивања, зато што ће се преостали блокови парчића захтевати од више суседа."
 
 #. Bram uses 30 seconds here.
 #: src/protocol/bittorrent/bittorrent.c:194
@@ -7842,40 +7010,24 @@ msgid "Peer snubbing interval"
 msgstr "Интервал снабовања суседа"
 
 #: src/protocol/bittorrent/bittorrent.c:196
-msgid ""
-"The number of seconds to wait for file data before assuming the peer has "
-"been snubbed."
-msgstr ""
-"Број секунди чекања на податке пре него што се претпостави да је сусед "
-"снабован."
+msgid "The number of seconds to wait for file data before assuming the peer has been snubbed."
+msgstr "Број секунди чекања на податке пре него што се претпостави да је сусед снабован."
 
 #: src/protocol/bittorrent/bittorrent.c:199
 msgid "Peer choke interval"
 msgstr "Интервал загушења суседа"
 
 #: src/protocol/bittorrent/bittorrent.c:201
-msgid ""
-"The number of seconds between updating the connection state and most "
-"importantly choke and unchoke peer connections. The choke period should be "
-"big enough for newly unchoked connections to get started but small enough to "
-"not allow freeriders too much room for stealing bandwidth."
-msgstr ""
-"Број секунди између ажурирања стања повезивања и пре свега загушења и "
-"одгушења повезивања са суседом. Период загушења би требало да буде довољно "
-"дуг да почну повезивања која су недавно одгушена али и довољно кратак да се "
-"злонамернима не дозволи превише простора за крађу протока."
+msgid "The number of seconds between updating the connection state and most importantly choke and unchoke peer connections. The choke period should be big enough for newly unchoked connections to get started but small enough to not allow freeriders too much room for stealing bandwidth."
+msgstr "Број секунди између ажурирања стања повезивања и пре свега загушења и одгушења повезивања са суседом. Период загушења би требало да буде довољно дуг да почну повезивања која су недавно одгушена али и довољно кратак да се злонамернима не дозволи превише простора за крађу протока."
 
 #: src/protocol/bittorrent/bittorrent.c:207
 msgid "Rarest first piece selection cutoff"
 msgstr "Одсецање избора парчића „прво најређи“"
 
 #: src/protocol/bittorrent/bittorrent.c:209
-msgid ""
-"The number of pieces to obtain before switching piece selection strategy "
-"from random to rarest first."
-msgstr ""
-"Број парчића који треба добити пре него што се стратегија избора парчића "
-"пребаци са произвољне на „прво најређи“."
+msgid "The number of pieces to obtain before switching piece selection strategy from random to rarest first."
+msgstr "Број парчића који треба добити пре него што се стратегија избора парчића пребаци са произвољне на „прво најређи“."
 
 #: src/protocol/bittorrent/bittorrent.c:212 src/protocol/http/http.c:84
 msgid "Allow blacklisting"
@@ -8126,9 +7278,7 @@ msgstr "Опције у вези са локалним CGI-јем."
 
 #: src/protocol/file/cgi.c:47
 msgid "Colon separated list of directories, where CGI scripts are stored."
-msgstr ""
-"Списак директоријума у којима су смештени CGI скриптови, раздвојених "
-"двотачкама."
+msgstr "Списак директоријума у којима су смештени CGI скриптови, раздвојених двотачкама."
 
 #: src/protocol/file/cgi.c:50
 msgid "Allow local CGI"
@@ -8156,38 +7306,24 @@ msgid "Allow reading special files"
 msgstr "Дозволити читање посебних датотека"
 
 #: src/protocol/file/file.c:48
-msgid ""
-"Whether to allow reading from non-regular files. Note this can be dangerous; "
-"reading /dev/urandom or /dev/zero can ruin your day!"
-msgstr ""
-"Да ли ће се дозволити читање посебних датотека. Ово може бити опасно: читање "
-"из /dev/urandom или из /dev/zero вам може загорчати живот!"
+msgid "Whether to allow reading from non-regular files. Note this can be dangerous; reading /dev/urandom or /dev/zero can ruin your day!"
+msgstr "Да ли ће се дозволити читање посебних датотека. Ово може бити опасно: читање из /dev/urandom или из /dev/zero вам може загорчати живот!"
 
 #: src/protocol/file/file.c:52
 msgid "Show hidden files in directory listing"
 msgstr "Приказивање сакривених датотека у листинзима директоријума"
 
 #: src/protocol/file/file.c:54
-msgid ""
-"When set to false, files with name starting with a dot will be hidden in "
-"local directory listings."
-msgstr ""
-"Када је ово постављено на „нетачно“, датотеке чији назив почиње тачком ће "
-"бити сакривене у листинзима локалних директоријума."
+msgid "When set to false, files with name starting with a dot will be hidden in local directory listings."
+msgstr "Када је ово постављено на „нетачно“, датотеке чији назив почиње тачком ће бити сакривене у листинзима локалних директоријума."
 
 #: src/protocol/file/file.c:57
 msgid "Try encoding extensions"
 msgstr "Пробање кодираних наставака"
 
 #: src/protocol/file/file.c:59
-msgid ""
-"When set, if we can't open a file named 'filename', we'll try to open "
-"'filename' with some encoding extension appended (ie. 'filename.gz'); it "
-"depends on the supported encodings."
-msgstr ""
-"Када је ово постављено, уколико датотека са називом „датотека“ не може да се "
-"отвори, покушаће се отварање уз додатак неког наставка кодирања (нпр. "
-"„датотека.gz“). Ово зависи од подржаних кодирања."
+msgid "When set, if we can't open a file named 'filename', we'll try to open 'filename' with some encoding extension appended (ie. 'filename.gz'); it depends on the supported encodings."
+msgstr "Када је ово постављено, уколико датотека са називом „датотека“ не може да се отвори, покушаће се отварање уз додатак неког наставка кодирања (нпр. „датотека.gz“). Ово зависи од подржаних кодирања."
 
 #. name:
 #: src/protocol/file/file.c:68
@@ -8228,12 +7364,8 @@ msgid "Host and port-number"
 msgstr "Хост и број порта"
 
 #: src/protocol/ftp/ftp.c:66
-msgid ""
-"Host and port-number (host:port) of the FTP proxy, or blank. If it's blank, "
-"FTP_PROXY environment variable is checked as well."
-msgstr ""
-"Хост и број порта (хост:порт) проксија за FTP. Може бити и празно, у ком "
-"случају се проверава и променљива окружења FTP_PROXY."
+msgid "Host and port-number (host:port) of the FTP proxy, or blank. If it's blank, FTP_PROXY environment variable is checked as well."
+msgstr "Хост и број порта (хост:порт) проксија за FTP. Може бити и празно, у ком случају се проверава и променљива окружења FTP_PROXY."
 
 #: src/protocol/ftp/ftp.c:70
 msgid "Anonymous password"
@@ -8249,9 +7381,7 @@ msgstr "Употреба пасивног режима (IPv4)"
 
 #: src/protocol/ftp/ftp.c:76
 msgid "Use PASV instead of PORT (passive vs active mode, IPv4 only)."
-msgstr ""
-"Користиће се наредба PASV уместо наредбе PORT (пасивни уместо активног "
-"режима, само уз IPv4)."
+msgstr "Користиће се наредба PASV уместо наредбе PORT (пасивни уместо активног режима, само уз IPv4)."
 
 #: src/protocol/ftp/ftp.c:79
 msgid "Use passive mode (IPv6)"
@@ -8259,8 +7389,7 @@ msgstr "Употреба пасивног режима (IPv6)"
 
 #: src/protocol/ftp/ftp.c:81
 msgid "Use EPSV instead of EPRT (passive vs active mode, IPv6 only)."
-msgstr ""
-"Користиће се EPSV уместо EPRT (пасивни уместо активног режима, само уз IPv6)."
+msgstr "Користиће се EPSV уместо EPRT (пасивни уместо активног режима, само уз IPv6)."
 
 #: src/protocol/ftp/ftp.c:1250 src/util/file.h:256
 msgid "%b %e  %Y"
@@ -8342,12 +7471,8 @@ msgid "Do not send Accept-Charset"
 msgstr "Не слати Accept-Charset"
 
 #: src/protocol/http/http.c:81
-msgid ""
-"The Accept-Charset header is quite long and sending it can trigger bugs in "
-"some rarely found servers."
-msgstr ""
-"Заглавље Accept-Charset је прилично дугачко, и његово слање понекад може "
-"покренути грешке код неких сервера."
+msgid "The Accept-Charset header is quite long and sending it can trigger bugs in some rarely found servers."
+msgstr "Заглавље Accept-Charset је прилично дугачко, и његово слање понекад може покренути грешке код неких сервера."
 
 #: src/protocol/http/http.c:86
 msgid "Allow blacklisting of buggy servers."
@@ -8358,14 +7483,8 @@ msgid "Broken 302 redirects"
 msgstr "Покварена 302-прослеђивања"
 
 #: src/protocol/http/http.c:90
-msgid ""
-"Broken 302 redirect (violates RFC but compatible with Netscape). This is a "
-"problem for a lot of web discussion boards and the like. If they will do "
-"strange things to you, try to play with this."
-msgstr ""
-"Покварена 302-прослеђивања (која нарушавају RFC, али су сагласна са Netscape-"
-"ом). Ово је проблем код великог броја дискусионих група на вебу и сл. "
-"Уколико се оне понашају чудно, покушајте да се играте овим избором."
+msgid "Broken 302 redirect (violates RFC but compatible with Netscape). This is a problem for a lot of web discussion boards and the like. If they will do strange things to you, try to play with this."
+msgstr "Покварена 302-прослеђивања (која нарушавају RFC, али су сагласна са Netscape-ом). Ово је проблем код великог броја дискусионих група на вебу и сл. Уколико се оне понашају чудно, покушајте да се играте овим избором."
 
 #: src/protocol/http/http.c:95
 msgid "No keepalive after POST requests"
@@ -8388,12 +7507,8 @@ msgid "HTTP proxy configuration."
 msgstr "Подешавања проксија за HTTP."
 
 #: src/protocol/http/http.c:109
-msgid ""
-"Host and port-number (host:port) of the HTTP proxy, or blank. If it's blank, "
-"HTTP_PROXY environment variable is checked as well."
-msgstr ""
-"Хост и број порта (хост:порт) проксија за HTTP, или празно. Ако је празно, "
-"проверава се и променљива окружења HTTP_PROXY."
+msgid "Host and port-number (host:port) of the HTTP proxy, or blank. If it's blank, HTTP_PROXY environment variable is checked as well."
+msgstr "Хост и број порта (хост:порт) проксија за HTTP, или празно. Ако је празно, проверава се и променљива окружења HTTP_PROXY."
 
 #: src/protocol/http/http.c:113
 msgid "Username"
@@ -8412,20 +7527,8 @@ msgid "Referer sending"
 msgstr "Слање упућивача"
 
 #: src/protocol/http/http.c:124
-msgid ""
-"HTTP referer sending options. HTTP referer is a special header sent in the "
-"HTTP requests, which is supposed to contain the previous page visited by the "
-"browser.This way, the server can know what link did you follow when "
-"accessing that page. However, this behaviour can unfortunately considerably "
-"affect privacy and can lead even to a security problem on some badly "
-"designed web pages."
-msgstr ""
-"Опције слања упућивача HTTP-а. Упућивач HTTP-а је посебно заглавље које се "
-"шаље у HTTP захтевима, које би требало да садржи претходну посећену страницу "
-"у читачу веба. Тако сервер може да зна коју везу сте пратили при приступу "
-"тој страници. Међутим, на несрећу, ово понашање може значајно да утиче на "
-"приватност и може да доведе и до безбедносних проблема на неким лоше "
-"замишљеним веб страницама."
+msgid "HTTP referer sending options. HTTP referer is a special header sent in the HTTP requests, which is supposed to contain the previous page visited by the browser.This way, the server can know what link did you follow when accessing that page. However, this behaviour can unfortunately considerably affect privacy and can lead even to a security problem on some badly designed web pages."
+msgstr "Опције слања упућивача HTTP-а. Упућивач HTTP-а је посебно заглавље које се шаље у HTTP захтевима, које би требало да садржи претходну посећену страницу у читачу веба. Тако сервер може да зна коју везу сте пратили при приступу тој страници. Међутим, на несрећу, ово понашање може значајно да утиче на приватност и може да доведе и до безбедносних проблема на неким лоше замишљеним веб страницама."
 
 #: src/protocol/http/http.c:132
 msgid "Policy"
@@ -8466,19 +7569,8 @@ msgid "Use UI language as Accept-Language"
 msgstr "Употреба језика сучеља као Accept-Language"
 
 #: src/protocol/http/http.c:152
-msgid ""
-"Request localised versions of documents from web-servers (using the Accept-"
-"Language header) using the language you have configured for ELinks' user-"
-"interface (this also affects navigator.language ECMAScript value available "
-"to scripts). Note that some see this as a potential security risk because it "
-"tells web-masters and the FBI sniffers about your language preference."
-msgstr ""
-"Захтеваће локализоване верзије докумената од веб сервера (преко заглавља "
-"Accept-Language) користећи језик који сте подесили за кориснички интерфејс "
-"ELinks-а (ово утиче и на вредност променљиве navigator.language ECMAScript-a "
-"која је доступна скриптовима). Имајте у виду да неки ово виде као "
-"потенцијални ризик по безбедност, јер саопштава вебмастерима и "
-"прислукивачима FBI-ја о вашем избору језика."
+msgid "Request localised versions of documents from web-servers (using the Accept-Language header) using the language you have configured for ELinks' user-interface (this also affects navigator.language ECMAScript value available to scripts). Note that some see this as a potential security risk because it tells web-masters and the FBI sniffers about your language preference."
+msgstr "Захтеваће локализоване верзије докумената од веб сервера (преко заглавља Accept-Language) користећи језик који сте подесили за кориснички интерфејс ELinks-а (ово утиче и на вредност променљиве navigator.language ECMAScript-a која је доступна скриптовима). Имајте у виду да неки ово виде као потенцијални ризик по безбедност, јер саопштава вебмастерима и прислукивачима FBI-ја о вашем избору језика."
 
 #. http://www.eweek.com/c/a/Desktops-and-Notebooks/Intel-Psion-End-Dispute-Concerning-Netbook-Trademark-288875/
 #. * responds with "Transfer-Encoding: chunked" and
@@ -8495,45 +7587,25 @@ msgstr "Активирање компресије у лету"
 
 #: src/protocol/http/http.c:171
 msgid ""
-"If enabled, the capability to receive compressed content (gzip and/or bzip2) "
-"is announced to the server, which usually sends the reply compressed, thus "
-"saving some bandwidth at slight CPU expense.\n"
+"If enabled, the capability to receive compressed content (gzip and/or bzip2) is announced to the server, which usually sends the reply compressed, thus saving some bandwidth at slight CPU expense.\n"
 "\n"
-"If ELinks displays a incomplete page or garbage, try disabling this option. "
-"If that helps, there may be a bug in the decompression part of ELinks. "
-"Please report such bugs.\n"
+"If ELinks displays a incomplete page or garbage, try disabling this option. If that helps, there may be a bug in the decompression part of ELinks. Please report such bugs.\n"
 "\n"
-"If ELinks has been compiled without compression support, this option has no "
-"effect. To check the supported features, see Help -> About."
+"If ELinks has been compiled without compression support, this option has no effect. To check the supported features, see Help -> About."
 msgstr ""
-"Ако је укључено, способност да се прима компримовани садржај (gzip и/или "
-"bzip2) се најављује серверу, који обично шаље компримован одговор, чувајући "
-"нешто протока на рачун незнатно мало времена CPU-а.\n"
+"Ако је укључено, способност да се прима компримовани садржај (gzip и/или bzip2) се најављује серверу, који обично шаље компримован одговор, чувајући нешто протока на рачун незнатно мало времена CPU-а.\n"
 "\n"
-"Ако ELinks прикаже непотпуну страницу или шум, покушајте да искључите ову "
-"опцију. Ако то помогне, можда постоји грешка у делу ELinks-а који се бави "
-"декомпресијом. Пријавите такве грешке.\n"
+"Ако ELinks прикаже непотпуну страницу или шум, покушајте да искључите ову опцију. Ако то помогне, можда постоји грешка у делу ELinks-а који се бави декомпресијом. Пријавите такве грешке.\n"
 "\n"
-"Ако је ELinks компајлиран без подршке за компресију, ова опција нема ефекта. "
-"Да бисте проверили подржане могућности, видите Помоћ -> О програму."
+"Ако је ELinks компајлиран без подршке за компресију, ова опција нема ефекта. Да бисте проверили подржане могућности, видите Помоћ -> О програму."
 
 #: src/protocol/http/http.c:184
 msgid "Activate HTTP TRACE debugging"
 msgstr "Активирање подршке за поправљање преко HTTP TRACE"
 
 #: src/protocol/http/http.c:186
-msgid ""
-"If active, all HTTP requests are sent with TRACE as their method rather than "
-"GET or POST. This is useful for debugging of both ELinks and various server-"
-"side scripts --- the server only returns the client's request back to the "
-"client verbatim. Note that this type of request may not be enabled on all "
-"servers."
-msgstr ""
-"Уколико је ово активирано, сви захтеви HTTP-а ће бити послати преко метода "
-"TRACE уместо GET или POST. Ово је корисно за дебаговање како ELinks-а, тако "
-"и бројних серверских скриптова, јер сервер клијенту враћа само дословни "
-"одговор клијента. Имајте у виду да ова врста захтева не мора бити активирана "
-"на свим серверима."
+msgid "If active, all HTTP requests are sent with TRACE as their method rather than GET or POST. This is useful for debugging of both ELinks and various server-side scripts --- the server only returns the client's request back to the client verbatim. Note that this type of request may not be enabled on all servers."
+msgstr "Уколико је ово активирано, сви захтеви HTTP-а ће бити послати преко метода TRACE уместо GET или POST. Ово је корисно за дебаговање како ELinks-а, тако и бројних серверских скриптова, јер сервер клијенту враћа само дословни одговор клијента. Имајте у виду да ова врста захтева не мора бити активирана на свим серверима."
 
 #. OSNews.com is supposed to be relying on the textmode token, at least.
 #: src/protocol/http/http.c:194
@@ -8542,30 +7614,18 @@ msgstr "Идентификација преко „User-Agent“"
 
 #: src/protocol/http/http.c:196
 msgid ""
-"Change the User Agent ID. That means identification string, which is sent to "
-"HTTP server when a document is requested. The 'textmode' token in the first "
-"field is our silent attempt to establish this as a standard for new textmode "
-"user agents, so that the webmasters can have just a single uniform test for "
-"these if they are e.g. pushing some lite version to them automagically.\n"
+"Change the User Agent ID. That means identification string, which is sent to HTTP server when a document is requested. The 'textmode' token in the first field is our silent attempt to establish this as a standard for new textmode user agents, so that the webmasters can have just a single uniform test for these if they are e.g. pushing some lite version to them automagically.\n"
 "\n"
-"Use \" \" if you don't want any User-Agent header to be sent at all. URI "
-"rewriting rules may still include parameters that reveal you are using "
-"ELinks.\n"
+"Use \" \" if you don't want any User-Agent header to be sent at all. URI rewriting rules may still include parameters that reveal you are using ELinks.\n"
 "\n"
 "%v in the string means ELinks version,\n"
 "%s in the string means system identification,\n"
 "%t in the string means size of the terminal,\n"
 "%b in the string means number of bars displayed by ELinks."
 msgstr ""
-"Мењање ID-ја корисничког агента. То је идентификациона ниска која се шаље "
-"HTTP серверу када се тражи документ. Кључна реч „textmode“ у првом пољу је "
-"само наш тихи покушај да ово успоставимо као стандард за будуће текстуалне "
-"читаче веба, тако да ово вебмастери могу тестирати на стандардизован начин "
-"и, нпр. подесити да се аутомагично шаље нека простија верзија веб странице.\n"
+"Мењање ID-ја корисничког агента. То је идентификациона ниска која се шаље HTTP серверу када се тражи документ. Кључна реч „textmode“ у првом пољу је само наш тихи покушај да ово успоставимо као стандард за будуће текстуалне читаче веба, тако да ово вебмастери могу тестирати на стандардизован начин и, нпр. подесити да се аутомагично шаље нека простија верзија веб странице.\n"
 "\n"
-"Користите „ “ (размак) ако уопште не желите да се шаље заглавље User-Agent. "
-"Правила за преписивање УРИ-ја и даље могу садржати параметре који одају да "
-"користите ELinks.\n"
+"Користите „ “ (размак) ако уопште не желите да се шаље заглавље User-Agent. Правила за преписивање УРИ-ја и даље могу садржати параметре који одају да користите ELinks.\n"
 "\n"
 "%v у нисци означава верзију ELinks-а,\n"
 "%s у нисци означава идентификацију система,\n"
@@ -8586,12 +7646,8 @@ msgid "HTTPS proxy configuration."
 msgstr "Подешавање проксија за HTTPS."
 
 #: src/protocol/http/http.c:224
-msgid ""
-"Host and port-number (host:port) of the HTTPS CONNECT proxy, or blank. If "
-"it's blank, HTTPS_PROXY environment variable is checked as well."
-msgstr ""
-"Хост и број порта (хост:порт) HTTPS CONNECT проксија, или празно. Ако је "
-"празно, проверава се и променљива окружења HTTPS_PROXY."
+msgid "Host and port-number (host:port) of the HTTPS CONNECT proxy, or blank. If it's blank, HTTPS_PROXY environment variable is checked as well."
+msgstr "Хост и број порта (хост:порт) HTTPS CONNECT проксија, или празно. Ако је празно, проверава се и променљива окружења HTTPS_PROXY."
 
 #. name:
 #: src/protocol/nntp/nntp.c:32 src/protocol/nntp/nntp.c:66
@@ -8607,26 +7663,16 @@ msgid "Default news server"
 msgstr "Подразумевани њуз сервер"
 
 #: src/protocol/nntp/nntp.c:38
-msgid ""
-"Used when resolving news: URIs. If set to the empty string the value of the "
-"NNTPSERVER environment variable will be used."
-msgstr ""
-"Користи се при разрешавању УРИ-ја са протоколом „news:“. Уколико се остави "
-"празно, биће коришћена вредност променљиве окружења NNTPSERVER."
+msgid "Used when resolving news: URIs. If set to the empty string the value of the NNTPSERVER environment variable will be used."
+msgstr "Користи се при разрешавању УРИ-ја са протоколом „news:“. Уколико се остави празно, биће коришћена вредност променљиве окружења NNTPSERVER."
 
 #: src/protocol/nntp/nntp.c:42
 msgid "Message header entries"
 msgstr "Ставке заглавља порука"
 
 #: src/protocol/nntp/nntp.c:44
-msgid ""
-"Comma separated list of which entries in the article header to show. E.g. "
-"'Subject' and 'From'. All header entries can be read in the header info "
-"dialog."
-msgstr ""
-"Списак ставки из заглавља чланака које би требало приказати, раздвојених "
-"запетама. Нпр. „Subject“ и „From“. Све ставке заглавља се могу погледати у "
-"дијалогу „Подаци о заглављу“."
+msgid "Comma separated list of which entries in the article header to show. E.g. 'Subject' and 'From'. All header entries can be read in the header info dialog."
+msgstr "Списак ставки из заглавља чланака које би требало приказати, раздвојених запетама. Нпр. „Subject“ и „From“. Све ставке заглавља се могу погледати у дијалогу „Подаци о заглављу“."
 
 #: src/protocol/protocol.c:246
 #, c-format
@@ -8646,14 +7692,8 @@ msgid "No-proxy domains"
 msgstr "Домени без проксија"
 
 #: src/protocol/protocol.c:283
-msgid ""
-"Comma separated list of domains for which the proxy (HTTP/FTP) should be "
-"disabled. Optionally, a port can be specified for some domains as well. If "
-"it's blank, NO_PROXY environment variable is checked as well."
-msgstr ""
-"Списак домена за које би требало деактивирати проксија (за HTTP или FTP), "
-"раздвојених запетама. Додатно се за неке домене може задати и порт. Уколико "
-"је ово празно, биће проверавана и променљива окружења NO_PROXY."
+msgid "Comma separated list of domains for which the proxy (HTTP/FTP) should be disabled. Optionally, a port can be specified for some domains as well. If it's blank, NO_PROXY environment variable is checked as well."
+msgstr "Списак домена за које би требало деактивирати проксија (за HTTP или FTP), раздвојених запетама. Додатно се за неке домене може задати и порт. Уколико је ово празно, биће проверавана и променљива окружења NO_PROXY."
 
 #. name:
 #: src/protocol/protocol.c:329
@@ -8665,48 +7705,24 @@ msgid "URI rewriting"
 msgstr "Мењање УРИ-ја"
 
 #: src/protocol/rewrite/rewrite.c:46
-msgid ""
-"Rules for rewriting URIs entered in the goto dialog. It makes it possible to "
-"define a set of prefixes that will be expanded if they match a string "
-"entered in the goto dialog. The prefixes can be dumb, meaning that they work "
-"only like URI abbreviations, or smart ones, making it possible to pass "
-"arguments to them like search engine keywords."
-msgstr ""
-"Правила за мењање УРИ-ја који се уносе у дијалог „Иди на“. Ово омогућава да "
-"се зада скуп префикса који ће бити проширени уколико се поклапају са ниском "
-"која се унесе у тај дијалог. Префикси могу да буду глупи, што значи да "
-"функционишу само као скраћенице за УРИ-јеве, или паметни, што омогућава да "
-"им се прослеђују аргументи као кључне речи претраживачима."
+msgid "Rules for rewriting URIs entered in the goto dialog. It makes it possible to define a set of prefixes that will be expanded if they match a string entered in the goto dialog. The prefixes can be dumb, meaning that they work only like URI abbreviations, or smart ones, making it possible to pass arguments to them like search engine keywords."
+msgstr "Правила за мењање УРИ-ја који се уносе у дијалог „Иди на“. Ово омогућава да се зада скуп префикса који ће бити проширени уколико се поклапају са ниском која се унесе у тај дијалог. Префикси могу да буду глупи, што значи да функционишу само као скраћенице за УРИ-јеве, или паметни, што омогућава да им се прослеђују аргументи као кључне речи претраживачима."
 
 #: src/protocol/rewrite/rewrite.c:54
 msgid "Enable dumb prefixes"
 msgstr "Активирање глупих префикса"
 
 #: src/protocol/rewrite/rewrite.c:56
-msgid ""
-"Enable dumb prefixes - simple URI abbreviations which can be written to the "
-"Goto URL dialog instead of actual URIs - i.e. if you write 'elinks' there, "
-"you are directed to http://elinks.cz/."
-msgstr ""
-"Активирање глупих префикса, једноставних скраћеница УРИ-ја које се могу "
-"уписати у дијалог „Иди на УРЛ“ уместо правих УРИ-ја. На пример, уколико тамо "
-"упишете „elinks“, бићете преусмерени на адресу http://elinks.cz/."
+msgid "Enable dumb prefixes - simple URI abbreviations which can be written to the Goto URL dialog instead of actual URIs - i.e. if you write 'elinks' there, you are directed to http://elinks.cz/."
+msgstr "Активирање глупих префикса, једноставних скраћеница УРИ-ја које се могу уписати у дијалог „Иди на УРЛ“ уместо правих УРИ-ја. На пример, уколико тамо упишете „elinks“, бићете преусмерени на адресу http://elinks.cz/."
 
 #: src/protocol/rewrite/rewrite.c:61
 msgid "Enable smart prefixes"
 msgstr "Активирање паметних префикса"
 
 #: src/protocol/rewrite/rewrite.c:63
-msgid ""
-"Enable smart prefixes - URI templates triggered by writing given "
-"abbreviation to the Goto URL dialog followed by a list of arguments from "
-"which the actual URI is composed - i.e. 'gg:search keywords' or 'gn search "
-"keywords for news'."
-msgstr ""
-"Активирање паметних префикса, шаблона УРИ-ја који се покрећу уписивањем "
-"одређених скраћеница у дијалог „Иди на УРЛ“, праћених списком аргумената од "
-"којих се саставља стварни УРИ. На пример, „gg:кључне речи“, или „gn кључне "
-"речи за њуз“."
+msgid "Enable smart prefixes - URI templates triggered by writing given abbreviation to the Goto URL dialog followed by a list of arguments from which the actual URI is composed - i.e. 'gg:search keywords' or 'gn search keywords for news'."
+msgstr "Активирање паметних префикса, шаблона УРИ-ја који се покрећу уписивањем одређених скраћеница у дијалог „Иди на УРЛ“, праћених списком аргумената од којих се саставља стварни УРИ. На пример, „gg:кључне речи“, или „gn кључне речи за њуз“."
 
 #: src/protocol/rewrite/rewrite.c:69
 msgid "Dumb Prefixes"
@@ -8759,10 +7775,7 @@ msgstr "Подразумевани шаблон"
 #: src/protocol/rewrite/rewrite.c:99
 #, no-c-format
 msgid ""
-"Default URI template used when the string entered in the goto dialog does "
-"not appear to be a URI or a filename (i.e. contains no '.', ':' or '/' "
-"characters), and does not match any defined prefixes. Set the value to \"\" "
-"to disable use of the default template rewrite rule.\n"
+"Default URI template used when the string entered in the goto dialog does not appear to be a URI or a filename (i.e. contains no '.', ':' or '/' characters), and does not match any defined prefixes. Set the value to \"\" to disable use of the default template rewrite rule.\n"
 "\n"
 "%c in the template means the current URL,\n"
 "%s in the template means the whole string from the goto\n"
@@ -8771,11 +7784,7 @@ msgid ""
 "   of %s,\n"
 "%% in the template means '%'."
 msgstr ""
-"Подразумевани шаблон УРИ-ја који се користи када ниска унета у дијалогу „Иди "
-"на“ не делује као УРИ или назив датотеке (тј. не садржи знакове „.“, „:“ или "
-"„/“), и не одговара ниједном задатом префиксу. Поставите вредност на "
-"„“ (празно) да искључите употребу правила преписивања подразумеваним "
-"шаблоном.\n"
+"Подразумевани шаблон УРИ-ја који се користи када ниска унета у дијалогу „Иди на“ не делује као УРИ или назив датотеке (тј. не садржи знакове „.“, „:“ или „/“), и не одговара ниједном задатом префиксу. Поставите вредност на „“ (празно) да искључите употребу правила преписивања подразумеваним шаблоном.\n"
 "\n"
 "%c у шаблону представља текући УРЛ,\n"
 "%s у шаблону представља целу ниску из дијалога „Иди на“,\n"
@@ -8799,20 +7808,12 @@ msgid "User protocols"
 msgstr "Кориснички протоколи"
 
 #: src/protocol/user.c:36
-msgid ""
-"User protocols. Options in this tree specify external handlers for the "
-"appropriate protocols. Ie. protocol.user.mailto.unix."
-msgstr ""
-"Кориснички протоколи. Опције у овом стаблу задају спољашње руковаоце "
-"одговарајућим протоколима. Нпр. protocol.user.mailto.unix."
+msgid "User protocols. Options in this tree specify external handlers for the appropriate protocols. Ie. protocol.user.mailto.unix."
+msgstr "Кориснички протоколи. Опције у овом стаблу задају спољашње руковаоце одговарајућим протоколима. Нпр. protocol.user.mailto.unix."
 
 #: src/protocol/user.c:47
-msgid ""
-"Handler (external program) for this protocol. Name the options in this tree "
-"after your system (ie. unix, unix-xwin)."
-msgstr ""
-"Руковалац (спољашњи програм) за овај протокол. Именујте опције у овом стаблу "
-"према називу вашег система (нпр. unix, unix-xwin)."
+msgid "Handler (external program) for this protocol. Name the options in this tree after your system (ie. unix, unix-xwin)."
+msgstr "Руковалац (спољашњи програм) за овај протокол. Именујте опције у овом стаблу према називу вашег система (нпр. unix, unix-xwin)."
 
 #: src/protocol/user.c:53
 msgid ""
@@ -9034,45 +8035,12 @@ msgid "Warning"
 msgstr "Упозорење"
 
 #: src/session/session.c:924
-msgid ""
-"You have an empty string in protocol.http.user_agent - this was a default "
-"value in the past, substituted by default ELinks User-Agent string. However, "
-"currently this means that NO User-Agent HEADER WILL BE SENT AT ALL - if this "
-"is really what you want, set its value to \" \", otherwise please delete the "
-"line with this setting from your configuration file (if you have no idea "
-"what I'm talking about, just do this), so that the correct default setting "
-"will be used. Apologies for any inconvience caused."
-msgstr ""
-"Променљива protocol.http.user_agent је постављена на празну ниску. Ово је "
-"раније била подразумевана вредност, која је замењивана ELinks-овом ниском "
-"User-Agent. Међутим, тренутно ово значи да се ЗАГЛАВЉЕ User-Agent УОПШТЕ "
-"НЕЋЕ СЛАТИ. Уколико је то оно што стварно желите, поставите њену вредност на "
-"„ “ (размак), а у супротном обришите ред са овом поставком из ваше датотеке "
-"са подешавањима (уколико уопште не знате о чему говорим, само урадите ово "
-"последње), па ће бити коришћена само подразумевана поставка. Извињавамо се "
-"због евентуалних непријатности које су овим проузроковане."
+msgid "You have an empty string in protocol.http.user_agent - this was a default value in the past, substituted by default ELinks User-Agent string. However, currently this means that NO User-Agent HEADER WILL BE SENT AT ALL - if this is really what you want, set its value to \" \", otherwise please delete the line with this setting from your configuration file (if you have no idea what I'm talking about, just do this), so that the correct default setting will be used. Apologies for any inconvience caused."
+msgstr "Променљива protocol.http.user_agent је постављена на празну ниску. Ово је раније била подразумевана вредност, која је замењивана ELinks-овом ниском User-Agent. Међутим, тренутно ово значи да се ЗАГЛАВЉЕ User-Agent УОПШТЕ НЕЋЕ СЛАТИ. Уколико је то оно што стварно желите, поставите њену вредност на „ “ (размак), а у супротном обришите ред са овом поставком из ваше датотеке са подешавањима (уколико уопште не знате о чему говорим, само урадите ово последње), па ће бити коришћена само подразумевана поставка. Извињавамо се због евентуалних непријатности које су овим проузроковане."
 
 #: src/session/session.c:943
-msgid ""
-"You have option config.saving_style set to a de facto obsolete value. The "
-"configuration saving algorithms of ELinks were changed from the last time "
-"you upgraded ELinks. Now, only those options which you actually changed are "
-"saved to the configuration file, instead of all the options. This simplifies "
-"our situation greatly when we see that some option has an inappropriate "
-"default value or we need to change the semantics of some option in a subtle "
-"way. Thus, we recommend you change the value of config.saving_style option "
-"to 3 in order to get the \"right\" behaviour. Apologies for any inconvience "
-"caused."
-msgstr ""
-"Променљива config.saving_style вам је подешена на де факто застарелу "
-"вредност. ELinks-ови алгоритми чувања подешавања су промењени од последњег "
-"пута када сте надоградили ELinks. Сада се само оне опције које сте заиста "
-"променили, а не све, чувају у датотеци са подешавањима. Ово значајно "
-"поједностављује ситуације када видимо да нека опција има лошу подразумевану "
-"вредност или када је потребно да незнатно променимо семантику неког избора. "
-"Зато вам препоручујемо да промените вредност избора config.saving_style на "
-"3, како бисте добили „исправно“ понашање. Извињавамо се због евентуалних "
-"непријатности које су овим проузроковане."
+msgid "You have option config.saving_style set to a de facto obsolete value. The configuration saving algorithms of ELinks were changed from the last time you upgraded ELinks. Now, only those options which you actually changed are saved to the configuration file, instead of all the options. This simplifies our situation greatly when we see that some option has an inappropriate default value or we need to change the semantics of some option in a subtle way. Thus, we recommend you change the value of config.saving_style option to 3 in order to get the \"right\" behaviour. Apologies for any inconvience caused."
+msgstr "Променљива config.saving_style вам је подешена на де факто застарелу вредност. ELinks-ови алгоритми чувања подешавања су промењени од последњег пута када сте надоградили ELinks. Сада се само оне опције које сте заиста променили, а не све, чувају у датотеци са подешавањима. Ово значајно поједностављује ситуације када видимо да нека опција има лошу подразумевану вредност или када је потребно да незнатно променимо семантику неког избора. Зато вам препоручујемо да промените вредност избора config.saving_style на 3, како бисте добили „исправно“ понашање. Извињавамо се због евентуалних непријатности које су овим проузроковане."
 
 #: src/session/session.c:968
 msgid "Welcome"
@@ -9095,22 +8063,18 @@ msgstr "Неисправан УРИ за претрагу"
 #: src/session/task.c:257
 #, c-format
 msgid ""
-"The URL you are about to follow might be maliciously crafted in order to "
-"confuse you. By following the URL you will be connecting to host \"%s\" as "
-"user \"%s\".\n"
+"The URL you are about to follow might be maliciously crafted in order to confuse you. By following the URL you will be connecting to host \"%s\" as user \"%s\".\n"
 "\n"
 "Do you want to go to URL %s?"
 msgstr ""
-"УРЛ на који ћете отићи може да буде злонамерно састављен како би вас збунио. "
-"Одласком на овај УРЛ повезаћете се са домаћином ,,%s`` као корисник ,,%s``.\n"
+"УРЛ на који ћете отићи може да буде злонамерно састављен како би вас збунио. Одласком на овај УРЛ повезаћете се са домаћином ,,%s`` као корисник ,,%s``.\n"
 "\n"
 "Желите ли да одем на УРЛ %s?"
 
 #: src/session/task.c:267
 #, c-format
 msgid "Do you want to follow the redirect and post form data to URL %s?"
-msgstr ""
-"Желите ли да пратим преусмерење и пошаљем податке из обрасца на УРЛ %s?"
+msgstr "Желите ли да пратим преусмерење и пошаљем податке из обрасца на УРЛ %s?"
 
 #: src/session/task.c:271
 #, c-format
@@ -9516,17 +8480,13 @@ msgstr "У анонимном режиму не можете да покреће
 #: src/viewer/text/textarea.c:688
 #, c-format
 msgid ""
-"You have exceeded the textarea's size limit: your input is %d bytes, but the "
-"maximum is %u bytes.\n"
+"You have exceeded the textarea's size limit: your input is %d bytes, but the maximum is %u bytes.\n"
 "\n"
-"Your input has been truncated, but you can still recover the text that you "
-"entered from this file: %s"
+"Your input has been truncated, but you can still recover the text that you entered from this file: %s"
 msgstr ""
-"Прекорачили сте ограничење величине textarea елемента: ваш унос има %d "
-"бајт(ова), али је максимум %u бајт(ова).\n"
+"Прекорачили сте ограничење величине textarea елемента: ваш унос има %d бајт(ова), али је максимум %u бајт(ова).\n"
 "\n"
-"Ваш унос је скраћен, али још можете опоравити текст који сте унели из "
-"следеће датотеке: %s"
+"Ваш унос је скраћен, али још можете опоравити текст који сте унели из следеће датотеке: %s"
 
 #: src/viewer/text/view.c:1208 src/viewer/text/view.c:1261
 msgid "Go to link"
@@ -9595,9 +8555,9 @@ msgstr "Прегледач"
 #~ msgid "HTTP 100 (???)"
 #~ msgstr "HTTP 100 (???)"
 
-#, fuzzy
 #~ msgid "Ruby Error"
 #~ msgstr "Грешка Рубија"
+#, fuzzy
 
 #~ msgid "Open a Lua console (DISABLED)"
 #~ msgstr "Отварање Луа конзоле (ДЕАКТИВИРАНО)"


### PR DESCRIPTION
Updates to po/sr.po, some translations missed in the last iteration, capitalization of language names (since they are menu items) and minor corrections. Diff may not be accurate due to lines not being wrapped.