### PR TITLE
[ win64 ] build_win64.sh, doc etc.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ elinks
 *.patch
 *.o
 features.log
+src/elinks.exe

--- a/build_win64.sh
+++ b/build_win64.sh
@@ -1,0 +1,50 @@
+#!/bin/sh
+#
+# WIndows x64 elinks cross-compilation
+#
+
+./autogen.sh
+
+CC=x86_64-w64-mingw32-gcc \
+LD=x86_64-w64-mingw32-ld \
+CFLAGS="-g -static -no-pie" \
+PKG_CONFIG="./pkg-config.sh" \
+./configure -C \
+--host=x86_64-w64-mingw32 \
+--enable-static \
+--without-brotli \
+--enable-utf-8 \
+--enable-256-colors \
+--without-quickjs \
+--without-lzma \
+--disable-gopher \
+--without-bzlib \
+--without-zlib \
+--disable-backtrace \
+--without-openssl \
+--disable-debug \
+--enable-fastmem \
+--without-perl \
+--disable-88-colors \
+--disable-true-color \
+--prefix=/usr \
+--disable-combining \
+--disable-bittorrent \
+--without-gnutls \
+--without-libev \
+--without-libevent \
+--without-terminfo \
+--disable-cgi \
+--without-ruby \
+--disable-sm-scripting \
+--without-python \
+--without-zstd \
+--without-x \
+--disable-nls
+if [ $? = 0 ]; then
+  sed -i 's/-Wall/-w/g' Makefile.config
+  make 
+else
+  print config failed  
+fi
+

--- a/doc/cross_mingw.txt
+++ b/doc/cross_mingw.txt
@@ -1,0 +1,41 @@
+
+  --[ HOWTO CROSS-COMPILE ELINKS FOR WIN64 ]--
+
+Hello All,
+
+so it could be annoying to get elinks compiled
+on Windows. Or Arm or just different architecture
+than Linux.
+
+if You'd like to do that there is a solution. And
+that's mingw. You can cross-compile on Linux for
+Windows etc.
+
+Now I'll assume You'd want to compile Windows x64
+binary on Linux. There is a script I provide. it's
+build_win64.sh. It would create static binary for
+Windows.
+
+On Debian You'd use x86_64-w64-mingw32-gcc or rather
+the mingw toolchain. It's usage it's quite straight
+forward just use it as environment variable:
+
+  CC=x86_64-w64-mingw32-gcc
+
+and to prepare the compilation configuration add:
+
+  --host=x86_64-w64-mingw32
+
+parameter to configure..
+
+And that's it. With the script You'll get the very
+basic binary for Windows. It could be run, it would
+open simple http pages. The support for the terminal
+is not very good. So I would advise You to use 
+environment variable TERM and set it to dumb. Like this:
+
+  set TERM=dumb
+
+And that's it for today.
+
+

--- a/src/intl/width.c
+++ b/src/intl/width.c
@@ -29,7 +29,7 @@
 
 
 struct Range {
-    uint first, last;
+    unsigned int first, last;
 };
 
 struct RangeLut {

--- a/src/network/dns.c
+++ b/src/network/dns.c
@@ -39,6 +39,10 @@
 #include "util/memory.h"
 #include "util/time.h"
 
+#ifdef WIN32
+#define NO_ASYNC_LOOKUP
+#endif
+
 
 struct dnsentry {
 	LIST_HEAD(struct dnsentry);

--- a/src/osdep/osdep.c
+++ b/src/osdep/osdep.c
@@ -359,23 +359,26 @@ exe(char *path)
 int
 exe_no_stdin(char *path) {
 	int ret;
-#if defined(F_GETFD) && defined(FD_CLOEXEC)
-	int flags;
+#ifndef WIN32
 
-	flags = fcntl(STDIN_FILENO, F_GETFD);
-	fcntl(STDIN_FILENO, F_SETFD, flags | FD_CLOEXEC);
-	ret = exe(path);
-	fcntl(STDIN_FILENO, F_SETFD, flags);
-#else
-	pid_t pid;
-
-	pid = fork();
-	if (pid == 0) {
-		close(STDIN_FILENO);
-		exit(exe(path));
-	}
-	else if (pid > 0)
-		waitpid(pid, &ret, 0);
+  #if defined(F_GETFD) && defined(FD_CLOEXEC)
+  	int flags;
+  
+  	flags = fcntl(STDIN_FILENO, F_GETFD);
+  	fcntl(STDIN_FILENO, F_SETFD, flags | FD_CLOEXEC);
+  	ret = exe(path);
+  	fcntl(STDIN_FILENO, F_SETFD, flags);
+  #else
+  	pid_t pid;
+  
+  	pid = fork();
+  	if (pid == 0) {
+  		close(STDIN_FILENO);
+  		exit(exe(path));
+  	}
+  	else if (pid > 0)
+  		waitpid(pid, &ret, 0);
+  #endif
 #endif
 	return ret;
 }
@@ -773,7 +776,7 @@ resize_window(int width, int height, int old_width, int old_height)
 
 /* Threads */
 
-#if defined(HAVE_BEGINTHREAD) || defined(CONFIG_OS_BEOS)
+#if defined(HAVE_BEGINTHREAD) || defined(CONFIG_OS_BEOS) || defined(CONFIG_OS_WIN32)
 
 struct tdata {
 	void (*fn)(void *, int);

--- a/src/osdep/osdep.h
+++ b/src/osdep/osdep.h
@@ -52,7 +52,9 @@ int resize_window(int, int, int, int);
 int can_resize_window(int);
 int can_open_os_shell(int);
 void set_highpri(void);
+#ifndef WIN32
 char *tempname(const char *dir, const char *pfx, char *suff);
+#endif
 
 #ifdef USE_OPEN_PREALLOC
 int open_prealloc(char *, int, int, off_t);

--- a/src/protocol/bittorrent/piececache.c
+++ b/src/protocol/bittorrent/piececache.c
@@ -1194,8 +1194,13 @@ start_bittorrent_resume(struct bittorrent_connection *bittorrent,
 	add_bytes_to_string(&info, (const char *)&meta->length, sizeof(meta->length));
 	add_bytes_to_string(&info, meta->source, meta->length);
 
+#ifndef WIN32
 	cache->resume_fd = start_thread(bittorrent_resume_writer, info.source,
-					info.length);
+
+#else
+
+	bittorrent_resume_writer(info.source, info.length);
+#endif
 	done_string(&info);
 
 	if (cache->resume_fd == -1)

--- a/src/terminal/kbd.c
+++ b/src/terminal/kbd.c
@@ -671,8 +671,13 @@ has_nul_byte:
 
 		if (fg == TERM_EXEC_FG) block_itrm();
 
+#ifndef WIN32
 		blockh = start_thread((void (*)(void *, int)) exec_thread,
 				      param, param_len);
+#else
+		exec_thread(param, param_len);
+
+#endif
 		mem_free(param);
 
 		if (blockh == -1) {

--- a/src/terminal/terminal.c
+++ b/src/terminal/terminal.c
@@ -230,11 +230,13 @@ exec_thread(char *path, int p)
 #if defined(HAVE_SETPGID) && !defined(CONFIG_OS_BEOS) && !defined(HAVE_BEGINTHREAD)
 	if (path[0] == TERM_EXEC_NEWWIN) setpgid(0, 0);
 #endif
+#ifndef WIN32
 	if (path[0] == TERM_EXEC_BG)
 		exe_no_stdin(path + 1);
 	else
 		exe(path + 1);
 	if (path[plen]) unlink(path + plen);
+#endif
 }
 
 void
@@ -293,8 +295,12 @@ exec_on_master_terminal(struct terminal *term,
 
 	if (fg == TERM_EXEC_FG) block_itrm();
 
+#ifndef WIN32
 	blockh = start_thread((void (*)(void *, int)) exec_thread,
 			      param, param_size);
+#else
+	exec_thread(param, param_size);
+#endif
 	fmem_free(param);
 	if (blockh == -1) {
 		if (fg == TERM_EXEC_FG) unblock_itrm();


### PR DESCRIPTION
Hello rkd77,

I would like to provide minimalistic build script for (build_win64.sh).
It was tested on Debian 10 using:
miky@deb:~/dev/work/elinks_win64$ x86_64-w64-mingw32-gcc --version
x86_64-w64-mingw32-gcc (GCC) 8.3-win32 20190406
It does compile the elinks.exe binary for Windows x64.
I did include simple document to describe the cross-compilation.

Thank You and have a nice day