### PR TITLE
[ win64 ] added openssl build support to docker, minor code changes

### DIFF
--- a/docker/win64/Dockerfile
+++ b/docker/win64/Dockerfile
@@ -1,9 +1,24 @@
 #
-# [ win64 ] elinks docker development environment 
+# [ win64 ] elinks docker development environment v0.1a
 #
 
 FROM debian:latest
 
 RUN apt-get update; apt-get -y install rsync vim screen git make automake gcc-mingw-w64-x86-64 bash g++-mingw-w64-x86-64 libssl-dev
+
+# [*] elinks openssl development support
+
+# install sources build tools and update
+RUN apt-get install -y apt-src && grep '^deb ' /etc/apt/sources.list | sed 's/deb /deb-src /' >> /etc/apt/sources.list && apt-src update
+
+# install openssl library source code
+RUN cd /root && apt-src install libssl-dev
+
+# build openssl library for win64
+RUN cd /root && cd `ls -d /root/openssl-*` && ./Configure mingw64 --cross-compile-prefix=x86_64-w64-mingw32- --prefix=/usr/local && make && make install
+
+# [*] elinks sources
+
+# get elinks source
 RUN cd /root; git clone https://github.com/rkd77/elinks
 

--- a/src/network/dns.c
+++ b/src/network/dns.c
@@ -173,8 +173,13 @@ do_real_lookup(char *name, struct sockaddr_storage **addrs, int *addrno,
 	{
 		struct in_addr inp;
 
+#ifndef WIN32
 		if (is_ip_address(name, strlen(name)) && inet_aton(name, &inp))
 			hostent = gethostbyaddr(&inp, sizeof(inp), AF_INET);
+#else
+		if (is_ip_address(name, strlen(name)) && inet_pton(name, &inp))
+			hostent = gethostbyaddr(&inp, sizeof(inp), AF_INET);
+#endif
 	}
 	if (!hostent)
 #endif

--- a/src/network/dns.c
+++ b/src/network/dns.c
@@ -173,7 +173,7 @@ do_real_lookup(char *name, struct sockaddr_storage **addrs, int *addrno,
 	{
 		struct in_addr inp;
 
-#ifndef WIN32
+#ifndef HAVE_INET_PTON
 		if (is_ip_address(name, strlen(name)) && inet_aton(name, &inp))
 			hostent = gethostbyaddr(&inp, sizeof(inp), AF_INET);
 #else

--- a/src/network/ssl/socket.c
+++ b/src/network/ssl/socket.c
@@ -284,7 +284,7 @@ match_uri_host_ip(const char *uri_host,
 	 * network byte order.  */
 	switch (ASN1_STRING_length(cert_host_asn1)) {
 	case 4:
-#ifndef win32
+#ifndef HAVE_INET_PTON
 		return inet_aton(uri_host, &uri_host_in) != 0
 		    && memcmp(cert_host_addr, &uri_host_in.s_addr, 4) == 0;
 #else
@@ -310,7 +310,6 @@ static int
 verify_callback(int preverify_ok, X509_STORE_CTX *ctx)
 {
 
-	X509_NAME *name;
 	X509 *cert;
 	SSL *ssl;
 	struct socket *socket;
@@ -362,7 +361,7 @@ verify_callback(int preverify_ok, X509_STORE_CTX *ctx)
 		sk_GENERAL_NAME_pop_free(alts, GENERAL_NAME_free);
 	}
 	if (!matched && !saw_dns_name) {
-
+		X509_NAME *name;
 		int cn_index;
 		X509_NAME_ENTRY *entry = NULL;
 

--- a/src/network/ssl/socket.c
+++ b/src/network/ssl/socket.c
@@ -70,6 +70,11 @@
 
 #endif
 
+/* Definition of X509_NAME causes compilation error on WIN32
+ * due to X509_NAME redefinition in wincrypt.h */
+#ifdef WIN32
+#undef X509_NAME
+#endif
 
 /* Refuse to negotiate TLS 1.0 and later protocols on @socket->ssl.
  * Without this, connecting to <https://www-s.uiuc.edu/> with GnuTLS
@@ -279,8 +284,14 @@ match_uri_host_ip(const char *uri_host,
 	 * network byte order.  */
 	switch (ASN1_STRING_length(cert_host_asn1)) {
 	case 4:
+#ifndef win32
 		return inet_aton(uri_host, &uri_host_in) != 0
 		    && memcmp(cert_host_addr, &uri_host_in.s_addr, 4) == 0;
+#else
+
+		return inet_pton(uri_host, &uri_host_in) != 0
+		    && memcmp(cert_host_addr, &uri_host_in.s_addr, 4) == 0;
+#endif
 
 #ifdef CONFIG_IPV6
 	case 16:
@@ -298,6 +309,8 @@ match_uri_host_ip(const char *uri_host,
 static int
 verify_callback(int preverify_ok, X509_STORE_CTX *ctx)
 {
+
+	X509_NAME *name;
 	X509 *cert;
 	SSL *ssl;
 	struct socket *socket;
@@ -348,9 +361,8 @@ verify_callback(int preverify_ok, X509_STORE_CTX *ctx)
 		/* Free the GENERAL_NAMES list and each element.  */
 		sk_GENERAL_NAME_pop_free(alts, GENERAL_NAME_free);
 	}
-
 	if (!matched && !saw_dns_name) {
-		X509_NAME *name;
+
 		int cn_index;
 		X509_NAME_ENTRY *entry = NULL;
 

--- a/src/osdep/stub.h
+++ b/src/osdep/stub.h
@@ -151,8 +151,13 @@ const char *elinks_inet_ntop(int af, const void *src, char *dst, size_t size);
 
 /* Silence various sparse warnings. */
 
+/* WIN32 This caused linker error on mingw w64 cross-compiler and in my
+ * honest opinion it's just here to silence the compiler as noted above */
+
+#ifndef WIN32
 #ifndef __builtin_stpcpy
 extern char *__builtin_stpcpy(char *dest, const char *src);
+#endif
 #endif
 
 #ifndef __builtin_mempcpy


### PR DESCRIPTION
Hello rkd77,

I'm offering this patch that's result of compilation of openssl suport on win64. It does compile but it does have some bugs in the similar manner like the http support on win64 had. 
This patch provides docker configuration for --with-openssl option.
I'm adding several changes to the code. Each my change is defined as preprocessor directive to eliminate impact on other platforms.
There weren't many changes needed for elinks to compile with the openssl support. One thing I'm unsure about is the different between inet_aton and inet_pton. The first (inet_aton) is not provided by openssl compiled on mingw so I just added the directive for WIN32 to use inet_pton.
There is a small difficulty with X509_NAME on win64 because wincrypt.h does redefine it as something completely different.

Thank You and have a nice day