### PR TITLE
[ win64 ] change in select - sleep only when nothing to do

### DIFF
--- a/src/osdep/win32/overrides.c
+++ b/src/osdep/win32/overrides.c
@@ -686,8 +686,11 @@ int win32_select (int num_fds, struct fd_set *rd, struct fd_set *wr,
 		}
 
 		/* Lower CPU Usage WIN64 */
-		Sleep (1);
-		if (rc) break;
+		if (rc) {
+			break;
+		} else {
+			Sleep (1);
+		}
 	}
 
 	rc = 0;


### PR DESCRIPTION
Hello rkd77,

this is probably better optimized to sleep only when there is nothing to do.

Please review the change and let me know if that's reasonable change.

Thank You & have a nice day