### PR TITLE
[ build ] lin64 js docker and automatic build

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -682,7 +682,7 @@ if test "x$CONFIG_QUICKJS" = x; then
 
 		CFLAGS="$CFLAGS $DB_LOCALSTORAGE_CFLAGS $XMLPLUSPLUS_CFLAGS"
 
-		LIBS="$LIBS $DB_LOCALSTORAGE_LIBS $XMLPLUSPLUS_LIBS /usr/lib/quickjs/libquickjs.a"
+		LIBS="$LIBS $DB_LOCALSTORAGE_LIBS $XMLPLUSPLUS_LIBS /usr/local/lib/quickjs/libquickjs.a"
 	else
 		AC_MSG_RESULT([no])
 	fi

--- a/docker/lin64/Dockerfile
+++ b/docker/lin64/Dockerfile
@@ -1,0 +1,33 @@
+#
+# [ lin64 ] elinks docker development environment v0.1d
+#
+# with quickjs support
+#
+
+# [*] base system
+
+# get latest debian
+FROM debian:latest
+
+# prepare system - commond base for all platforms
+RUN apt-get update && apt-get -y install bash \
+  rsync vim screen git make automake
+
+# [*] get sources and req libs
+RUN cd /root && git clone https://github.com/bellard/quickjs && cd /root && git clone https://github.com/libxmlplusplus/libxmlplusplus && cd /root && apt-get install -y libxml2-dev g++
+
+# [*] build quickjs
+RUN cd /root/quickjs && make && make install
+
+# [*] build libxmlplusplus
+RUN apt-get install -y mm-common && cd /root/libxmlplusplus && ./autogen.sh && ./configure --enable-static --prefix=/usr/local && make && make install
+
+RUN ln -s /usr/local/include/libxml++-5.0/libxml++ /usr/local/include/libxml++ && ln -s /usr/local/lib/libxml++-5.0/include/libxml++config.h /usr/local/include/libxml++config.h && ln -s /usr/include/libxml2/libxml /usr/include/libxml
+
+# [*] prepare openssl library and javascript preqreqs
+RUN apt-get -y install libssl-dev libsqlite3-dev zlib1g-dev liblzma-dev libtre-dev libidn11-dev libexpat1-dev
+
+# disable caching for this step to get the newest elinks sources
+ARG NOCACHE=1
+RUN cd /root && git clone https://github.com/rkd77/elinks
+

--- a/docker/lin64/build.sh
+++ b/docker/lin64/build.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+docker build --build-arg NOCACHE=0 -t "elinks-lin64-dev:latest" .

--- a/docker/lin64/cleanup.sh
+++ b/docker/lin64/cleanup.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+docker container stop elinks-lin64-dev
+docker container rm elinks-lin64-dev
+#docker image rm elinks-lin64-dev

--- a/docker/lin64/run.sh
+++ b/docker/lin64/run.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+docker run -it \
+  --name=elinks-lin64-dev \
+  -v /tmp:/tmp/host \
+  elinks-lin64-dev:latest \
+  /bin/bash

--- a/docker/lin64/shell.sh
+++ b/docker/lin64/shell.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+docker start elinks-lin64-dev
+docker exec -it elinks-lin64-dev bash


### PR DESCRIPTION
Hello rkd77,

I'm offering patch for javascript build. This patch offers:
1] running
$ build.sh build 
- builds automatically the elinks. This is preparement for automatic building elinks in docker for several different platforms without human intervention
2] There is a small change in configuration.ac ... if You don't mind I replace the /usr/lib/libquickjs.a for /usr/local/lib/libquickjs.a The change is because that's the default location for the static library
3] Offering dockerfile for elinks with javascript for linux x64.

Thank You & have a nice day

mtatton