### PR TITLE
configure: Fix an "implicit int" warning

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -390,7 +390,7 @@ void foo(const char *format, ...) {
 
        exit(0);
 }
-main() { foo("hello\n"); }
+int main() { foo("hello\n"); }
 ]])],[el_cv_HAVE_C99_VSNPRINTF=yes],[el_cv_HAVE_C99_VSNPRINTF=no],[el_cv_HAVE_C99_VSNPRINTF=cross])])
 if test x"$el_cv_HAVE_C99_VSNPRINTF" = x"yes"; then
 	EL_DEFINE(HAVE_C99_VSNPRINTF, [C99 compliant vsnprintf()])


### PR DESCRIPTION
configure defines a main function without a return type, leading to a -Wimplicit-int warning (enabled by default in C99 and later dialects). This commit fixes that.

Related to:
https://fedoraproject.org/wiki/Changes/PortingToModernC
https://fedoraproject.org/wiki/Toolchain/PortingToModernC