### PR TITLE
[doc] use join_paths method & datadir config for generating default doc_dir

### DIFF
--- a/doc/meson.build
+++ b/doc/meson.build
@@ -19,7 +19,7 @@ endif
 doc_dir = get_option('docdir')
 
 if doc_dir == ''
-    doc_dir = get_option('prefix') / 'share/doc/elinks'
+    doc_dir = join_paths(get_option('prefix'), get_option('datadir'), 'doc', 'elinks')
 endif
 
 if pod2html.found()


### PR DESCRIPTION
This is more sane than hardcoding 'share/doc/elinks'
Also using join_paths method os better for portability to non-Unix systems