### PR TITLE
Allow building with -Dlibsixel=false

### DIFF
--- a/src/bfu/dialog.c
+++ b/src/bfu/dialog.c
@@ -475,7 +475,9 @@ dialog_func(struct window *win, struct term_event *ev)
 		case EVENT_RESIZE:
 		case EVENT_REDRAW:
 			redraw_dialog(dlg_data, 1);
+#ifdef  CONFIG_LIBSIXEL                       
 			win->term->sixel = 0;
+#endif
 			break;
 
 		case EVENT_MOUSE:
@@ -490,7 +492,9 @@ dialog_func(struct window *win, struct term_event *ev)
 
 		case EVENT_ABORT:
 			dialog_ev_abort(dlg_data);
+#ifdef  CONFIG_LIBSIXEL                       
 			win->term->sixel = 1;
+#endif
 			break;
 	}
 }

--- a/src/bfu/menu.c
+++ b/src/bfu/menu.c
@@ -1014,7 +1014,9 @@ menu_handler(struct window *win, struct term_event *ev)
 			 * menu->selected here. */
 			scroll_menu(menu, 0, 1);
 			display_menu(win->term, menu);
+#ifdef  CONFIG_LIBSIXEL
 			win->term->sixel = 0;
+#endif
 			break;
 
 		case EVENT_MOUSE:
@@ -1028,7 +1030,9 @@ menu_handler(struct window *win, struct term_event *ev)
 			break;
 
 		case EVENT_ABORT:
+#ifdef  CONFIG_LIBSIXEL
 			win->term->sixel = 1;
+#endif
 			free_menu_items(menu->items);
 			break;
 	}
@@ -1369,7 +1373,9 @@ mainmenu_handler(struct window *win, struct term_event *ev)
 			break;
 
 		case EVENT_ABORT:
+#ifdef  CONFIG_LIBSIXEL
 			win->term->sixel = 1;
+#endif
 			break;
 	}
 }

--- a/src/document/document.cpp
+++ b/src/document/document.cpp
@@ -78,7 +78,9 @@
 #include "network/dns.h"
 #include "protocol/uri.h"
 #include "terminal/draw.h"
+#ifdef CONFIG_LIBSIXEL
 #include "terminal/sixel.h"
+#endif
 #include "util/color.h"
 #include "util/error.h"
 #include "util/lists.h"

--- a/src/document/plain/renderer.c
+++ b/src/document/plain/renderer.c
@@ -26,7 +26,9 @@
 #include "protocol/uri.h"
 #include "terminal/color.h"
 #include "terminal/draw.h"
+#ifdef CONFIG_LIBSIXEL
 #include "terminal/sixel.h"
+#endif
 #include "util/color.h"
 #include "util/error.h"
 #include "util/memory.h"
@@ -57,7 +59,9 @@ struct plain_renderer {
 	/* Are we doing line compression */
 	unsigned int compress:1;
 
+#ifdef CONFIG_LIBSIXEL
 	unsigned int sixel:1;
+#endif
 };
 
 #define realloc_document_links(doc, size) \

--- a/src/terminal/screen.c
+++ b/src/terminal/screen.c
@@ -20,7 +20,9 @@
 #include "terminal/hardio.h"
 #include "terminal/kbd.h"
 #include "terminal/screen.h"
+#ifdef CONFIG_LIBSIXEL
 #include "terminal/sixel.h"
+#endif
 #include "terminal/terminal.h"
 #ifdef CONFIG_TERMINFO
 #include "terminal/terminfo.h"

--- a/src/terminal/terminal.cpp
+++ b/src/terminal/terminal.cpp
@@ -35,7 +35,9 @@
 #include "terminal/hardio.h"
 #include "terminal/kbd.h"
 #include "terminal/screen.h"
+#ifdef CONFIG_LIBSIXEL
 #include "terminal/sixel.h"
+#endif
 #include "terminal/terminal.h"
 #ifdef CONFIG_TERMINFO
 #include "terminal/terminfo.h"
@@ -56,7 +58,11 @@ redraw_terminal(struct terminal *term)
 {
 	struct term_event ev;
 
+#ifdef CONFIG_LIBSIXEL
 	set_redraw_term_event(&ev, term->width, term->height, term->cell_width, term->cell_height);
+#else
+	set_redraw_term_event(&ev, term->width, term->height, 0, 0);
+#endif
 	term_send_event(term, &ev);
 }
 
@@ -65,7 +71,11 @@ redraw_terminal_cls(struct terminal *term)
 {
 	struct term_event ev;
 
+#ifdef CONFIG_LIBSIXEL
 	set_resize_term_event(&ev, term->width, term->height, term->cell_width, term->cell_height);
+#else
+	set_resize_term_event(&ev, term->width, term->height, 0, 0);
+#endif
 	term_send_event(term, &ev);
 }
 

--- a/src/terminal/window.c
+++ b/src/terminal/window.c
@@ -45,7 +45,11 @@ redraw_windows(enum windows_to_redraw which, struct window *win)
 		return;
 	}
 
+#ifdef CONFIG_LIBSIXEL
 	set_redraw_term_event(&ev, term->width, term->height, term->cell_width, term->cell_height);
+#else
+	set_redraw_term_event(&ev, term->width, term->height, 0, 0);
+#endif
 	for (; win != end; win = win->prev) {
 		if (!inactive_tab(win))
 			win->handler(win, &ev);
@@ -69,7 +73,11 @@ add_window(struct terminal *term, window_handler_T handler, void *data)
 	win->term = term;
 	win->type = WINDOW_NORMAL;
 	add_at_pos((struct window *) &term->windows, win);
+#ifdef CONFIG_LIBSIXEL
 	set_init_term_event(&ev, term->width, term->height, term->cell_width, term->cell_height);
+#else
+	set_init_term_event(&ev, term->width, term->height, 0, 0);
+#endif
 	win->handler(win, &ev);
 }
 

--- a/src/viewer/text/draw.c
+++ b/src/viewer/text/draw.c
@@ -30,7 +30,9 @@
 #include "session/location.h"
 #include "session/session.h"
 #include "terminal/draw.h"
+#ifdef CONFIG_LIBSIXEL
 #include "terminal/sixel.h"
+#endif
 #include "terminal/tab.h"
 #include "terminal/terminal.h"
 #include "util/error.h"


### PR DESCRIPTION
hi
this adds a number of trivial conditionals to allow building with libsixel disabled

works for me

For  the ``set_*_term_event()`` calls I have set dummy 0 values when libsixel is disabled: don't know if this is acceptable or needs some more appropriate fix...


thanks
ciao
-g
