### PR TITLE
Fix compilation with Perl 5.38

### DIFF
--- a/src/main/object.h
+++ b/src/main/object.h
@@ -11,7 +11,7 @@ extern "C" {
 #define DEBUG_REFCOUNT
 #endif
 
-struct object {
+struct elinks_object {
 	int refcount;
 #ifdef CONFIG_DEBUG
 	char *name;
@@ -20,10 +20,10 @@ struct object {
 
 #define OBJECT_HEAD(type)						\
 	LIST_HEAD_EL(type);						\
-	struct object object
+	struct elinks_object object
 
 struct object_head {
-	OBJECT_HEAD(struct object *);
+	OBJECT_HEAD(struct elinks_object *);
 };
 
 #ifdef DEBUG_REFCOUNT

--- a/src/protocol/uri.c
+++ b/src/protocol/uri.c
@@ -1578,7 +1578,7 @@ struct uri_cache_entry {
 
 struct uri_cache {
 	struct hash *map;
-	struct object object;
+	struct elinks_object object;
 };
 
 static struct uri_cache uri_cache;

--- a/src/protocol/uri.h
+++ b/src/protocol/uri.h
@@ -89,7 +89,7 @@ struct uri {
 	unsigned int form:1;	/* URI originated from form */
 
 	/* Usage count object. */
-	struct object object;
+	struct elinks_object object;
 };
 
 enum uri_errno {


### PR DESCRIPTION
Perl now includes own `struct object` which clashes with elinks implementation. Renamed `struct object` to `struct elinks_object` to avoid it.

Bug: https://bugs.gentoo.org/909042