### PR TITLE
[gemini] Use paragraph tags on gemtext empty lines

### DIFF
--- a/src/document/gemini/renderer.c
+++ b/src/document/gemini/renderer.c
@@ -152,6 +152,10 @@ render_gemini_document(struct cache_entry *cached, struct document *document,
 			if (buffer->source[i] == 13 || buffer->source[i] == 10) break;
 		}
 
+		if (begin == i) {
+			add_to_string(&html, "</p><p>");
+		}
+
 		if (begin < i) {
 			int len = i - begin;
 


### PR DESCRIPTION
This patch makes paragraphs separated by an empty new line appear after an empty new line when rendered in elinks.

Previously, for a gemtext source that looks like this:

    First para
    Second line

    Second para

It renders like this:

    First para
    Second line
    Second para

After this patch, they now render like this:

    First para
    Second line

    Second para

Unfortunately this also adds a `</p>` to the start of the HTML, as well as a `<p>` at the end, both redundant; but since the HTML is parsed and rendered later on, it does not seem to alter how the document would look.

    </p><p> First para <br> Second line </p><p> Second para </p><p>

I could possibly add a `first_paragraph` variable and a `i != buffer->length` check to remove the first `</p>` and last `<p>` in the HTML, making the HTML source "prettier". But I don't believe that would be too beneficial, considering the performance tradeoff in executing these two extra checks for each empty new line encountered.

For testing please see: [hedy.tilde.cafe/tmp/paragraphs.gmi](https://portal.mozz.us/gemini/hedy.tilde.cafe/tmp/paragraphs.gmi)

---

<details>
<summary>Screenshots</summary>
<img width="800" alt="image before" src="https://github.com/rkd77/elinks/assets/50042066/10f0ccdc-411d-45cb-8160-0e19b3220d30">

Before ⬆️ 

<img width="800" alt="image after" src="https://github.com/rkd77/elinks/assets/50042066/3c8db762-191c-4c71-b0b4-77148d7348c4">

After ⬆️ 

</details>