### PR TITLE
fix suspend in session master when fork_on_start

### DIFF
--- a/src/main/main.c
+++ b/src/main/main.c
@@ -60,6 +60,8 @@
 
 struct program program;
 
+pid_t master_pid = 0;
+
 static int ac;
 static char **av;
 static int init_b = 0;
@@ -193,6 +195,9 @@ init(void)
 	    || get_cmd_opt_bool("source")
 	    || (fd = init_interlink()) == -1) {
 
+#ifdef HAVE_GETPID
+		master_pid = getpid();
+#endif
 		parse_options_again();
 		init_b = 1;
 		init_modules(builtin_modules);

--- a/src/main/main.h
+++ b/src/main/main.h
@@ -23,6 +23,7 @@ struct program {
 };
 
 extern struct program program;
+extern pid_t master_pid;
 
 void shrink_memory(int);
 void parse_options_again(void);

--- a/src/osdep/signals.c
+++ b/src/osdep/signals.c
@@ -77,7 +77,7 @@ sig_tstp(struct terminal *term)
 
 	block_itrm();
 #if defined (SIGCONT) && defined(SIGTTOU)
-	if (master_pid) {
+	if (pid == master_pid) {
 		pid_t newpid = fork();
 		if (!newpid) {
 			int r;

--- a/src/terminal/terminal.c
+++ b/src/terminal/terminal.c
@@ -54,8 +54,6 @@ INIT_LIST_OF(struct terminal, terminals);
 struct hash *temporary_files;
 static void check_if_no_terminal(void);
 
-pid_t master_pid = 0;
-
 void
 clean_temporary_files(void)
 {
@@ -190,12 +188,6 @@ init_term(int fdin, int fdout)
 	term->fdin = fdin;
 	term->fdout = fdout;
 	term->master = (term->fdout == get_output_handle());
-
-#ifdef HAVE_GETPID
-	if (term->master) {
-		master_pid = getpid();
-	}
-#endif
 
 	term->blocked = -1;
 


### PR DESCRIPTION
After commit b102addf9 following request #287, `term->master` is used as test to see if this is session master process we want to wakeup with SIGCONT after suspend (master must be kept running, or other slaves will block).  Test uses comparison `term->fdout == 1`, which is never true in the case of forked master when `ui.session.fork_on_start`.  The forked master has different (>10) fdout descriptor numbers, so it will never be `term->master` and thus `master_pid` will still have its initialized value 0.

Instead we can get the pid directly after forking, and use the interlink creation attempt to decide whether this is a master or slave process depending on successful connect().  This was tested with both `fork_on_start=1` and `fork_on_start=0` with different suspend/resume permutations and seems to work correctly now.

Note that `term->master` is used in several places: `exec_on_terminal()`, `try_to_draw_images()`, `redraw_screen()`, `erase_screen()`, `get_resource_info()` and `get_master_session()`, so it could be that `fork_on_start` has other issues.