### PR TITLE
remove 300ms startup delay and optimize fork_on_start

### DIFF
--- a/src/main/interlink.c
+++ b/src/main/interlink.c
@@ -530,19 +530,10 @@ init_interlink(void)
 		if (pid == -1) return -1;
 
 		if (pid > 0) {
-			int i;
-
-			for (i = 1; i <= (MAX_BIND_TRIES+2); ++i) {
-				fd = connect_to_af_unix();
-
-				if (fd != -1) {
-					master_pid = pid;
-					return fd;
-				}
-				elinks_usleep(BIND_TRIES_DELAY * i);
-			}
-			return -1;
+			master_pid = pid;
+			return connect_to_af_unix();
 		}
+
 		/* child */
 		master_pid = getpid();
 		close_terminal_pipes();


### PR DESCRIPTION
In [a previous issue](https://github.com/rkd77/elinks/issues/287#issuecomment-1984869268) it was noted that the first elinks session has a long startup delay of ~350ms, whereas slaves start instantly.  A workaround is to use `dtach` for the first session, and leave it headless, so all subsequent `elinks` are slaves.

It was [pointed out](https://github.com/rkd77/elinks/issues/287#issuecomment-1983532712) that `ui.sessions.fork_on_start` already was designed for this purpose.  However, even in that case, the first-session delay still remains.

After instrumenting key sites in `main.c` and `interlink.c` following the call path `init()` -> `init_interlink()` -> `connect_to_af_unix()` like so:

``` c
struct timeval tstart, tlast;

void
print_elapsed(const char *whence)
{
       struct timeval tnow, ttotal, tdelta;
       unsigned long fromstart, fromlast;

       gettimeofday(&tnow, NULL);

       timersub(&tnow, &tstart, &ttotal);
       timersub(&tnow, &tlast, &tdelta);
       fromstart = ttotal.tv_sec * 1e6 + ttotal.tv_usec;
       fromlast = tdelta.tv_sec * 1e6 + tdelta.tv_usec;

       fprintf(stderr, "%8d%10lu +%8lu %-s\n",
               getpid(), fromstart, fromlast, whence);

       memcpy(&tlast, &tnow, sizeof(struct timeval));
}
```
it was discovered that this delay is due to a fixed sequence of 300ms on start, attempting `connect()` to existing master on `AF_UNIX` socket, going to sleep and retrying several times.

Timings for unmodified branch with `fork_on_start=0`:
```
 3377146         1 +       1 init_start
 3377146      4099 +    4098 init_after_home
 3377146      4116 +      17 interlink_pre_af_connect
 3377146      4118 +       2 afconnect_before_getaddr
 3377146      4122 +       4 afconnect_after_getaddr
 3377146     54376 +   50254 afconnect_post_sleep1 No such file or directory
 3377146    154653 +  100277 afconnect_post_sleep2 No such file or directory
 3377146    304948 +  150295 afconnect_post_sleep3 No such file or directory
 3377146    304974 +      26 afconnect_after_loop
 3377146    304976 +       2 interlink_post_af_connect
 3377146    315086 +   10110 interlink_child_prebind
 3377146    315680 +     594 interlink_child_postbind
 3377146    315685 +       5 init_after_interlink
 3377146    349608 +   33923 init_after_modules
 3377146    349752 +     144 init_end
```
We wait an extra 50ms for `fork_on_start=1`, because the master has to finish seting up the AF_UNIX socket and start the retry loop again.  However we get most of the 50ms back because the fork overhead, and module init, happen in parallel in the child while we wait:
```
 3377604         0 +       0 init_start
 3377604      4333 +    4333 init_after_home
 3377604      4349 +      16 interlink_pre_af_connect
 3377604      4351 +       2 afconnect_before_getaddr
 3377604      4355 +       4 afconnect_after_getaddr
 3377604     54584 +   50229 afconnect_post_sleep1 No such file or directory
 3377604    154787 +  100203 afconnect_post_sleep2 No such file or directory
 3377604    305093 +  150306 afconnect_post_sleep3 No such file or directory
 3377604    305115 +      22 afconnect_after_loop
 3377604    305117 +       2 interlink_post_af_connect
 3377604    306225 +    1108 interlink_prefork
 3377604    306554 +     329 interlink_parent_preconnect
 3377604    306570 +      16 afconnect_before_getaddr
 3377604    306586 +      16 afconnect_after_getaddr
 3377605    306664 +     439 interlink_child_prebind
 3377605    306810 +     146 interlink_child_postbind
 3377605    306813 +       3 init_after_interlink
 3377605    328902 +   22089 init_after_modules
 3377605    328933 +      31 init_end
 3377604    356732 +   50146 afconnect_post_sleep1 No such file or directory
 3377604    356774 +      42 interlink_parent_connect
 3377604    356857 +      83 init_end
```
The attached patches:

1. eliminate this unnecessary delay for the first time: master is either there or it isn't, no need to try again.
2. use a pipe-written byte delivered by the child (new master) to its waiting parent, once the listener is set up, in `fork_on_start=1` case, so it can retry the second `connect()` attempt with immediate success.

This avoids the delay completely in non-fork case, and minimizes delay in fork case.

Timings for `nowait-connect` branch with `fork_on_start=0`:
```
 3399320         0 +       0 init_start
 3399320      4310 +    4310 init_after_home
 3399320      4324 +      14 interlink_pre_af_connect
 3399320      4351 +      27 afconnect_before_getaddr
 3399320      4355 +       4 afconnect_after_getaddr
 3399320      4374 +      19 afconnect_after_connect
 3399320      4376 +       2 interlink_post_af_connect
 3399320      5684 +    1308 interlink_child_prebind
 3399320      5824 +     140 interlink_child_postbind
 3399320      5830 +       6 init_after_interlink
 3399320      5832 +       2 init_before_modules
 3399320     37862 +   32030 init_after_modules
 3399320     38010 +     148 init_end
```
Timings for `nowait-connect` branch with `fork_on_start=1`:
```
 3399545         0 +       0 init_start
 3399545      4447 +    4447 init_after_home
 3399545      4463 +      16 interlink_pre_af_connect
 3399545      4465 +       2 afconnect_before_getaddr
 3399545      4469 +       4 afconnect_after_getaddr
 3399545      4491 +      22 afconnect_after_connect
 3399545      4493 +       2 interlink_post_af_connect
 3399546      5988 +    1495 interlink_child_prebind
 3399546      6179 +     191 interlink_child_postbind
 3399546      6183 +       4 init_after_interlink
 3399546      6185 +       2 init_before_modules
 3399545      6185 +    1692 afconnect_before_getaddr
 3399545      6237 +      52 afconnect_after_getaddr
 3399545      6249 +      12 interlink_parent_connected
 3399545      6297 +      48 init_end
 3399546     35605 +   29420 init_after_modules
 3399546     35638 +      33 init_end
```
More details in the commit messages.

Trace instrumentation diff against master, from my [interlink-trace](https://github.com/smemsh/elinks/compare/master...interlink-trace) branch.

Trace instrumentation diff against this branch, from my [nowait-connect-trace](https://github.com/smemsh/elinks/compare/nowait-connect...nowait-connect-trace) branch.
