### PR TITLE
Update INSTALL

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -3,6 +3,10 @@ Elinks installation guidelines
 
   Quick guide for the impatient:
 
+	meson setup builddir && cd builddir && meson compile && meson install
+
+  Alternatively, instead of meson:
+
 	./configure && make && make install
 
   Check out the bottom of this file if you're upgrading from Links or an older


### PR DESCRIPTION
I added a note in the INSTALL documentation to prefer meson instead of ./configure / make / make install.

I think if meson is used, autogen.sh is no longer needed (when I tested, it worked without running autogen.sh). Should it be deleted? Should I edit the INSTALL documentation to explain that it is not needed if meson is used?