### PR TITLE
Use get_option('libdir') instead of 'lib'

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -399,11 +399,18 @@ endif
 
 st = get_option('static')
 
+libdir = get_option('libdir')
+if libdir[0] != '/' and libdir[1] != ':'
+    libdir = get_option('prefix') / libdir
+endif
+
+extra_library_dirs = [libdir]
+
 deps = []
 if conf_data.get('CONFIG_GZIP')
     zdeps = dependency('zlib', static: st, required: false)
     if not zdeps.found()
-        zdeps = compiler.find_library('z', static: st, dirs: [get_option('prefix')+'/lib'])
+        zdeps = compiler.find_library('z', static: st, dirs: extra_library_dirs)
     endif
     if zdeps.found()
         deps += zdeps
@@ -420,7 +427,7 @@ if conf_data.get('CONFIG_LIBEV')
     conf_data.set('HAVE_LIBEV_EVENT_H', compiler.has_header('libev/event.h'))
     conf_data.set('HAVE_LIBEV', true)
     eh = '#include <libev/event.h>'
-    eventdeps = compiler.find_library('ev', static: st)
+    eventdeps = compiler.find_library('ev', static: st, dirs: extra_library_dirs)
     deps += eventdeps
     conf_data.set('CONFIG_LIBEVENT', false)
     code1 = '''#include <libev/event.h>
@@ -447,7 +454,7 @@ ssldeps = []
 if conf_data.get('CONFIG_OPENSSL')
     ssldeps = dependency('openssl', static: st, required: false)
     if not ssldeps.found()
-        ssldeps = compiler.find_library('ssl', static: st, dirs: [get_option('prefix')+'/lib'])
+        ssldeps = compiler.find_library('ssl', static: st, dirs: extra_library_dirs)
     endif
     deps += ssldeps
     conf_data.set('USE_OPENSSL', true)
@@ -499,7 +506,7 @@ endif
 if conf_data.get('CONFIG_BZIP2')
     bz2deps = dependency('bzip2', static: st, required: false)
     if not bz2deps.found()
-        bz2deps = compiler.find_library('bz2', static: st, dirs: [get_option('prefix')+'/lib'])
+        bz2deps = compiler.find_library('bz2', static: st, dirs: extra_library_dirs)
     endif
     deps += bz2deps
 endif
@@ -520,7 +527,7 @@ curldeps = false
 if conf_data.get('CONFIG_ECMASCRIPT_SMJS') or conf_data.get('CONFIG_QUICKJS') or conf_data.get('CONFIG_MUJS')
     curldeps = dependency('libcurl', static: st, required: false)
     if not curldeps.found()
-        curldeps = compiler.find_library('curl', static: st, dirs: [get_option('prefix')+'/lib'])
+        curldeps = compiler.find_library('curl', static: st, dirs: extra_library_dirs)
     endif
     if curldeps.found()
         deps += curldeps
@@ -531,7 +538,7 @@ endif
 if not conf_data.get('CONFIG_LIBCURL') and get_option('libcurl')
     curldeps = dependency('libcurl', static: st, required: false)
     if not curldeps.found()
-        curldeps = compiler.find_library('curl', static: st, dirs: [get_option('prefix')+'/lib'])
+        curldeps = compiler.find_library('curl', static: st, dirs: extra_library_dirs)
     endif
     if curldeps.found()
         deps += curldeps
@@ -583,7 +590,7 @@ endif
 if conf_data.get('CONFIG_SCRIPTING_LUA')
     luadeps = dependency(luapkg, static: st, required: false)
     if not luadeps.found()
-        luadeps = compiler.find_library(luapkg, static: st, dirs: [get_option('prefix')+'/lib'])
+        luadeps = compiler.find_library(luapkg, static: st, dirs: extra_library_dirs)
     endif
     deps += luadeps
 endif
@@ -591,7 +598,7 @@ endif
 if conf_data.get('CONFIG_XBEL_BOOKMARKS')
     expatdeps = dependency('expat', static: st, required: false)
     if not expatdeps.found()
-        expatdeps = compiler.find_library('expat', static: st, dirs: [get_option('prefix')+'/lib'])
+        expatdeps = compiler.find_library('expat', static: st, dirs: extra_library_dirs)
     endif
     deps += expatdeps
 endif
@@ -637,7 +644,7 @@ if conf_data.get('CONFIG_SCRIPTING_GUILE')
 endif
 
 if conf_data.get('CONFIG_FSP')
-    fspdeps = compiler.find_library('fsplib', static: st)
+    fspdeps = compiler.find_library('fsplib', static: st, dirs: extra_library_dirs)
     deps += fspdeps
 endif
 
@@ -662,7 +669,7 @@ endif
 if conf_data.get('CONFIG_QUICKJS')
     quickjsdeps = compiler.find_library('quickjs', static: st, required: false)
     if not quickjsdeps.found()
-        quickjsdeps = compiler.find_library('quickjs/libquickjs', static: true, dirs: [get_option('prefix')+'/lib'])
+        quickjsdeps = compiler.find_library('quickjs/libquickjs', static: true, dirs: extra_library_dirs)
     endif
     deps += quickjsdeps
     deps += dep_atomic
@@ -691,7 +698,7 @@ if conf_data.get('CONFIG_LIBSIXEL')
 endif
 
 if conf_data.get('CONFIG_OS_DOS')
-    wattdeps = compiler.find_library('watt', static: st, dirs: [get_option('prefix')+'/lib'])
+    wattdeps = compiler.find_library('watt', static: st, dirs: extra_library_dirs)
     deps += wattdeps
 else
     wattdeps = []
@@ -1060,7 +1067,7 @@ if compiler.has_function('ASN1_STRING_get0_data', prefix: '#include <openssl/asn
     conf_data.set('HAVE_ASN1_STRING_GET0_DATA', 1)
 endif
 
-iconvdeps = compiler.find_library('iconv', static: st, dirs: [get_option('prefix')+'/lib'], required: false)
+iconvdeps = compiler.find_library('iconv', static: st, dirs: extra_library_dirs, required: false)
 if iconvdeps.found()
     deps += iconvdeps
 endif
@@ -1124,7 +1131,7 @@ conf_data.set('CONFDIR', sysconfdir)
 conf_data.set('sysconfdir', sysconfdir)
 conf_data.set('SOMETHING', '@SOMETHING@')
 conf_data.set('api_srcdir', srcdir + '/src')
-conf_data.set('LIBDIR', get_option('prefix') / 'lib')
+conf_data.set('LIBDIR', libdir)
 conf_data.set('LOCALEDIR', get_option('prefix') / 'share/locale')
 
 conf_data.set('HAVE_SA_STORAGE', true)


### PR DESCRIPTION
This prevents misincluding wrong libraries in systems with multilib directories like in Gentoo:

Example error output where the included library file should be `/usr/lib64/libbz2.so` instead of `/usr/lib/libbz2.so`:

```
x86_64-pc-linux-gnu-gcc  -o src/elinks src/elinks.p/bookmarks_backend_xbel.c.o src/elinks.p/bookmarks_backend_common.c.o src/elinks.p/bookmarks_backend_default.c.o src/elinks.p/bookmarks_bookmarks.c.o src/elinks.p/bookmarks_dialogs.c.o src/elinks.p/cookies_cookies.c.o src/elinks.p/cookies_dialogs.c.o src/elinks.p/cookies_path.c.o src/elinks.p/cookies_parser.c.o src/elinks.p/dom_css_scanner.c.o src/elinks.p/dom_sgml_docbook_docbook.c.o src/elinks.p/dom_sgml_html_html.c.o src/elinks.p/dom_sgml_rss_rss.c.o src/elinks.p/dom_sgml_xbel_xbel.c.o src/elinks.p/dom_sgml_dump.c.o src/elinks.p/dom_sgml_parser.c.o src/elinks.p/dom_sgml_scanner.c.o src/elinks.p/dom_sgml_sgml.c.o src/elinks.p/dom_configuration.c.o src/elinks.p/dom_node.c.o src/elinks.p/dom_select.c.o src/elinks.p/dom_stack.c.o src/elinks.p/dom_scanner.c.o src/elinks.p/ecmascript_ecmascript.c.o src/elinks.p/ecmascript_ecmascript-c.c.o src/elinks.p/ecmascript_localstorage-db.c.o src/elinks.p/ecmascript_mujs.c.o src/elinks.p/ecmascript_timer.c.o src/elinks.p/ecmascript_mujs_attr.c.o src/elinks.p/ecmascript_mujs_attributes.c.o src/elinks.p/ecmascript_mujs_collection.c.o src/elinks.p/ecmascript_mujs_console.c.o src/elinks.p/ecmascript_mujs_css.c.o src/elinks.p/ecmascript_mujs_customevent.c.o src/elinks.p/ecmascript_mujs_document.c.o src/elinks.p/ecmascript_mujs_element.c.o src/elinks.p/ecmascript_mujs_event.c.o src/elinks.p/ecmascript_mujs_form.c.o src/elinks.p/ecmascript_mujs_forms.c.o src/elinks.p/ecmascript_mujs_history.c.o src/elinks.p/ecmascript_mujs_implementation.c.o src/elinks.p/ecmascript_mujs_input.c.o src/elinks.p/ecmascript_mujs_keyboard.c.o src/elinks.p/ecmascript_mujs_localstorage.c.o src/elinks.p/ecmascript_mujs_location.c.o src/elinks.p/ecmascript_mujs_mapa.c.o src/elinks.p/ecmascript_mujs_message.c.o src/elinks.p/ecmascript_mujs_navigator.c.o src/elinks.p/ecmascript_mujs_nodelist.c.o src/elinks.p/ecmascript_mujs_screen.c.o src/elinks.p/ecmascript_mujs_style.c.o src/elinks.p/ecmascript_mujs_unibar.c.o src/elinks.p/ecmascript_mujs_url.c.o src/elinks.p/ecmascript_mujs_window.c.o src/elinks.p/ecmascript_mujs_xhr.c.o src/elinks.p/ecmascript_libdom_parse.c.o src/elinks.p/formhist_formhist.c.o src/elinks.p/formhist_dialogs.c.o src/elinks.p/globhist_globhist.c.o src/elinks.p/globhist_dialogs.c.o src/elinks.p/scripting_lua_lua.c.o src/elinks.p/scripting_lua_hooks.c.o src/elinks.p/scripting_lua_core.c.o src/elinks.p/scripting_scripting.c.o src/elinks.p/bfu_button.c.o src/elinks.p/bfu_checkbox.c.o src/elinks.p/bfu_dialog.c.o src/elinks.p/bfu_group.c.o src/elinks.p/bfu_hierbox.c.o src/elinks.p/bfu_hotkey.c.o src/elinks.p/bfu_inpfield.c.o src/elinks.p/bfu_inphist.c.o src/elinks.p/bfu_listbox.c.o src/elinks.p/bfu_listmenu.c.o src/elinks.p/bfu_menu.c.o src/elinks.p/bfu_msgbox.c.o src/elinks.p/bfu_style.c.o src/elinks.p/bfu_text.c.o src/elinks.p/bfu_widget.c.o src/elinks.p/bfu_leds.c.o src/elinks.p/cache_cache.c.o src/elinks.p/cache_dialogs.c.o src/elinks.p/config_cmdline.c.o src/elinks.p/config_conf.c.o src/elinks.p/config_dialogs.c.o src/elinks.p/config_domain.c.o src/elinks.p/config_home.c.o src/elinks.p/config_kbdbind.c.o src/elinks.p/config_options.c.o src/elinks.p/config_opttypes.c.o src/elinks.p/config_timer.c.o src/elinks.p/config_urlhist.c.o src/elinks.p/dialogs_document.c.o src/elinks.p/dialogs_download.c.o src/elinks.p/dialogs_edit.c.o src/elinks.p/dialogs_info.c.o src/elinks.p/dialogs_menu.c.o src/elinks.p/dialogs_options.c.o src/elinks.p/dialogs_progress.c.o src/elinks.p/dialogs_status.c.o src/elinks.p/document_css_apply.c.o src/elinks.p/document_css_css.c.o src/elinks.p/document_css_parser.c.o src/elinks.p/document_css_property.c.o src/elinks.p/document_css_scanner.c.o src/elinks.p/document_css_stylesheet.c.o src/elinks.p/document_css_value.c.o src/elinks.p/document_dom_renderer.c.o src/elinks.p/document_dom_rss.c.o src/elinks.p/document_dom_source.c.o src/elinks.p/document_dom_util.c.o src/elinks.p/document_libdom_corestrings.c.o src/elinks.p/document_libdom_css.c.o src/elinks.p/document_libdom_doc.c.o src/elinks.p/document_libdom_mapa.c.o src/elinks.p/document_libdom_renderer.c.o src/elinks.p/document_libdom_renderer2.c.o src/elinks.p/document_gemini_renderer.c.o src/elinks.p/document_html_parser_forms.c.o src/elinks.p/document_html_parser_general.c.o src/elinks.p/document_html_parser_link.c.o src/elinks.p/document_html_parser_parse.c.o src/elinks.p/document_html_parser_stack.c.o src/elinks.p/document_html_parser_table.c.o src/elinks.p/document_html_frames.c.o src/elinks.p/document_html_iframes.c.o src/elinks.p/document_html_parse-meta-refresh.c.o src/elinks.p/document_html_parser.c.o src/elinks.p/document_html_renderer.c.o src/elinks.p/document_html_tables.c.o src/elinks.p/document_plain_renderer.c.o src/elinks.p/document_docdata.c.o src/elinks.p/document_document.c.o src/elinks.p/document_format.c.o src/elinks.p/document_forms.c.o src/elinks.p/document_options.c.o src/elinks.p/document_refresh.c.o src/elinks.p/document_renderer.c.o src/elinks.p/encoding_bzip2.c.o src/elinks.p/encoding_gzip.c.o src/elinks.p/encoding_lzma.c.o src/elinks.p/encoding_zstd.c.o src/elinks.p/encoding_encoding.c.o src/elinks.p/intl_libintl.c.o src/elinks.p/intl_charsets.c.o src/elinks.p/intl_width.c.o src/elinks.p/main_interlink.c.o src/elinks.p/main_event.c.o src/elinks.p/main_main.c.o src/elinks.p/main_module.c.o src/elinks.p/main_select.c.o src/elinks.p/main_timer.c.o src/elinks.p/main_version.c.o src/elinks.p/mime_backend_mailcap.c.o src/elinks.p/mime_backend_mimetypes.c.o src/elinks.p/mime_backend_common.c.o src/elinks.p/mime_backend_default.c.o src/elinks.p/mime_dialogs.c.o src/elinks.p/mime_mime.c.o src/elinks.p/network_ssl_match-hostname.c.o src/elinks.p/network_ssl_ssl.c.o src/elinks.p/network_ssl_socket.c.o src/elinks.p/network_connection.c.o src/elinks.p/network_dns.c.o src/elinks.p/network_progress.c.o src/elinks.p/network_socket.c.o src/elinks.p/network_state.c.o src/elinks.p/osdep_unix_unix.c.o src/elinks.p/osdep_unix_bsd.c.o src/elinks.p/osdep_getifaddrs.c.o src/elinks.p/osdep_newwin.c.o src/elinks.p/osdep_osdep.c.o src/elinks.p/osdep_signals.c.o src/elinks.p/osdep_stub.c.o src/elinks.p/osdep_sysname.c.o src/elinks.p/protocol_curl_ftp.c.o src/elinks.p/protocol_curl_http.c.o src/elinks.p/protocol_rewrite_rewrite.c.o src/elinks.p/protocol_auth_auth.c.o src/elinks.p/protocol_auth_dialogs.c.o src/elinks.p/protocol_auth_digest.c.o src/elinks.p/protocol_file_file.c.o src/elinks.p/protocol_file_mailcap.c.o src/elinks.p/protocol_http_blacklist.c.o src/elinks.p/protocol_http_codes.c.o src/elinks.p/protocol_http_http.c.o src/elinks.p/protocol_http_post.c.o src/elinks.p/protocol_data.c.o src/elinks.p/protocol_ftpparse.c.o src/elinks.p/protocol_about.c.o src/elinks.p/protocol_common.c.o src/elinks.p/protocol_date.c.o src/elinks.p/protocol_header.c.o src/elinks.p/protocol_protocol.c.o src/elinks.p/protocol_proxy.c.o src/elinks.p/protocol_uri.c.o src/elinks.p/protocol_user.c.o src/elinks.p/session_download.c.o src/elinks.p/session_history.c.o src/elinks.p/session_location.c.o src/elinks.p/session_session.c.o src/elinks.p/session_task.c.o src/elinks.p/terminal_mouse.c.o src/elinks.p/terminal_terminfo.c.o src/elinks.p/terminal_color.c.o src/elinks.p/terminal_draw.c.o src/elinks.p/terminal_event.c.o src/elinks.p/terminal_hardio.c.o src/elinks.p/terminal_kbd.c.o src/elinks.p/terminal_screen.c.o src/elinks.p/terminal_tab.c.o src/elinks.p/terminal_terminal.c.o src/elinks.p/terminal_window.c.o src/elinks.p/util_qs_parse_qs_parse.c.o src/elinks.p/util_fastfind.c.o src/elinks.p/util_scanner.c.o src/elinks.p/util_base64.c.o src/elinks.p/util_color.c.o src/elinks.p/util_conv.c.o src/elinks.p/util_env.c.o src/elinks.p/util_error.c.o src/elinks.p/util_file.c.o src/elinks.p/util_hash.c.o src/elinks.p/util_md5.c.o src/elinks.p/util_memlist.c.o src/elinks.p/util_memory.c.o src/elinks.p/util_random.c.o src/elinks.p/util_secsave.c.o src/elinks.p/util_snprintf.c.o src/elinks.p/util_string.c.o src/elinks.p/util_time.c.o src/elinks.p/viewer_dump_dump.c.o src/elinks.p/viewer_text_marks.c.o src/elinks.p/viewer_text_draw.c.o src/elinks.p/viewer_text_form.c.o src/elinks.p/viewer_text_link.c.o src/elinks.p/viewer_text_search.c.o src/elinks.p/viewer_text_textarea.c.o src/elinks.p/viewer_text_view.c.o src/elinks.p/viewer_text_vs.c.o src/elinks.p/viewer_action.c.o src/elinks.p/viewer_timer.c.o src/elinks.p/viewer_viewer.c.o src/elinks.p/vernum.c.o -Wl,--as-needed -Wl,--no-undefined -O2 -pipe -march=native -fno-strict-aliasing -Wl,-O1 -Wl,--as-needed -Wl,--start-group /usr/lib64/libz.so /usr/lib64/libssl.so /usr/lib64/libcrypto.so /usr/lib64/libzstd.so /usr/lib64/liblzma.so /usr/lib64/libX11.so /usr/lib/libbz2.so /usr/lib64/libsqlite3.so /usr/lib64/libcurl.so /usr/lib64/libcss.so /usr/lib64/libparserutils.so /usr/lib64/libwapcaplet.so /usr/lib64/libdom.so /usr/lib64/libhubbub.so /usr/lib64/liblua5.1.so /usr/lib64/libexpat.so /usr/lib/gcc/x86_64-pc-linux-gnu/13/../../../../lib64/libgpm.so /usr/lib/gcc/x86_64-pc-linux-gnu/13/../../../../lib64/libmujs.so /usr/lib64/libncursesw.so /usr/lib64/libtinfow.so -Wl,--end-group
/usr/lib/gcc/x86_64-pc-linux-gnu/13/../../../../x86_64-pc-linux-gnu/bin/ld: /usr/lib/libbz2.so: error adding symbols: file in wrong format
collect2: error: ld returned 1 exit status
```
Some files in `app-arch/bzip2`:
```
/usr/lib/libbz2.so.1.0.8
/usr/lib/libbz2.so.1.0
/usr/lib/libbz2.so
/usr/lib/libbz2.so.1
/usr/lib64/libbz2.so.1.0.8
/usr/lib64/libbz2.so.1.0
/usr/lib64/libbz2.so
/usr/lib64/libbz2.so.1
```
