### PR TITLE
silence signedness warnings and errors

### DIFF
--- a/src/cache/cache.c
+++ b/src/cache/cache.c
@@ -950,7 +950,7 @@ check_sha(const char *name, const unsigned char *data, size_t len, const char *c
 	mdctx = EVP_MD_CTX_new();
 	EVP_DigestInit_ex(mdctx, md, NULL);
 	EVP_DigestUpdate(mdctx, data, len);
-	EVP_DigestFinal_ex(mdctx, md_value, &md_len);
+	EVP_DigestFinal_ex(mdctx, md_value, (unsigned int*)&md_len);
 	EVP_MD_CTX_free(mdctx);
 	int outlen = 0;
 	unsigned char *b64 = base64_encode_bin(md_value, md_len, &outlen);
@@ -983,13 +983,13 @@ validate_cache_integrity(struct cache_entry *cached, const char *integrity)
 
 		if (!strncmp("sha512-", ch, 7)) {
 			ch += 7;
-			ret = check_sha("sha512", frag->data, frag->length, ch);
+			ret = check_sha("sha512", (const unsigned char*)frag->data, frag->length, ch);
 		} else if (!strncmp("sha384-", ch, 7)) {
 			ch += 7;
-			ret = check_sha("sha384", frag->data, frag->length, ch);
+			ret = check_sha("sha384", (const unsigned char*)frag->data, frag->length, ch);
 		} else if (!strncmp("sha256-", ch, 7)) {
 			ch += 7;
-			ret = check_sha("sha256", frag->data, frag->length, ch);
+			ret = check_sha("sha256", (const unsigned char*)frag->data, frag->length, ch);
 		}
 		if (ret) {
 			return ret;

--- a/src/document/libdom/css.c
+++ b/src/document/libdom/css.c
@@ -2423,8 +2423,8 @@ el_match_selector(const char *selector, void *node)
 {
 	struct string text;
 	css_error code;
-	size_t size;
-	uint32_t count;
+	//size_t size;
+	//uint32_t count;
 	css_stylesheet_params params;
 	css_stylesheet *sheet = NULL;
 	css_select_ctx *select_ctx = NULL;

--- a/src/formhist/formhist.c
+++ b/src/formhist/formhist.c
@@ -187,7 +187,7 @@ cont:
 
 			if (form->dontsave) continue;
 
-			enc_value = *value ? base64_decode(value)
+			enc_value = *value ? (char*)base64_decode((unsigned char*)value)
 					   : stracpy(value);
 			if (!enc_value) goto fail;
 
@@ -253,7 +253,7 @@ save_formhist_to_file(void)
 				 * $ cat ~/.config/elinks/formhist
 				 * we don't want someone behind our back to read our
 				 * password (androids don't count). */
-				encvalue = base64_encode(sv->value);
+				encvalue = (char*)base64_encode((unsigned char*)sv->value);
 			} else {
 				encvalue = stracpy("");
 			}

--- a/src/protocol/data.c
+++ b/src/protocol/data.c
@@ -137,7 +137,7 @@ data_protocol_handler(struct connection *conn)
 
 	datalen = uri->datalen - (data_start - uri->data);
 	if (base64) {
-		char *decoded = base64_decode_bin(data_start, datalen, &decodedlen);
+		char *decoded = (char*)base64_decode_bin((const unsigned char*)data_start, datalen, &decodedlen);
 
 		if (!decoded) {
 			abort_connection(conn, connection_state(S_OUT_OF_MEM));

--- a/src/protocol/http/http.c
+++ b/src/protocol/http/http.c
@@ -814,7 +814,7 @@ http_send_header(struct socket *socket)
 
 				proxy_data = straconcat(user, ":", passwd, (char *) NULL);
 				if (proxy_data) {
-					char *proxy_64 = base64_encode(proxy_data);
+					char *proxy_64 = (char*)base64_encode((unsigned char*)proxy_data);
 
 					if (proxy_64) {
 						add_to_string(&header, "Proxy-Authorization: Basic ");
@@ -1032,7 +1032,7 @@ http_send_header(struct socket *socket)
 			id = straconcat(entry->user, ":", entry->password,
 					(char *) NULL);
 			if (id) {
-				char *base64 = base64_encode(id);
+				char *base64 = (char*)base64_encode((unsigned char*)id);
 
 				mem_free_set(&id, base64);
 			}

--- a/src/util/base64.c
+++ b/src/util/base64.c
@@ -21,7 +21,7 @@ base64_encode(unsigned char *in)
 	assert(in && *in);
 	if_assert_failed return NULL;
 
-	return base64_encode_bin(in, strlen(in), NULL);
+	return base64_encode_bin(in, strlen((const char*)in), NULL);
 }
 
 unsigned char *
@@ -69,7 +69,7 @@ base64_decode(const unsigned char *in)
 	assert(in && *in);
 	if_assert_failed return NULL;
 
-	return base64_decode_bin(in, strlen(in), NULL);
+	return base64_decode_bin(in, strlen((const char*)in), NULL);
 }
 
 /** Decode a Base64 string.


### PR DESCRIPTION
Compiles with zero warnings and errors using:
```sh
gcc version 14.2.1 20240921 (Gentoo 14.2.1_p20240921 p5)
GNU assembler version 2.43.1 (x86_64-pc-linux-gnu) using BFD version (Gentoo 2.43 p2) 2.43.1
```