### PR TITLE
[docker] update dependencies

### DIFF
--- a/docker/alpine-static/Dockerfile
+++ b/docker/alpine-static/Dockerfile
@@ -52,8 +52,7 @@ RUN apk add \
  musl-dev \
  nghttp2-dev \
  nghttp2-static \
- c-ares-dev \
- c-ares-static
+ c-ares-dev
 
 ## [*] netsurf libs
 # get netsurf source


### PR DESCRIPTION
Alpine Linux moved the .a file from the c-ares-static subpackage to the origin c-ares. As c-ares-dev depends on c-ares, we can just drop the c-ares-static dependency.

Ref: https://gitlab.alpinelinux.org/alpine/aports/-/commit/400607034d000fcf84ca2d3ed6a00a69429aee2d