### PR TITLE
Fix default value for libdomdeps to empty list instead of false

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -555,7 +555,7 @@ if conf_data.get('CONFIG_ECMASCRIPT_SMJS') or conf_data.get('CONFIG_QUICKJS') or
 endif
 
 conf_data.set('CONFIG_LIBDOM', false)
-libdomdeps = false
+libdomdeps = []
 
 if conf_data.get('CONFIG_ECMASCRIPT_SMJS') or conf_data.get('CONFIG_QUICKJS') or conf_data.get('CONFIG_MUJS')
     libdomdeps = dependency('libdom', static: st, version: '>=0.4.2', required: false)


### PR DESCRIPTION
When it was false, meson complained that it shouldn't be a boolean value, see: https://salsa.debian.org/aelmahmoudy/elinks/-/jobs/6836245/raw