### PR TITLE
[sftp] add declaration of ftp_curl_handle_error

### DIFF
--- a/src/protocol/curl/sftp.h
+++ b/src/protocol/curl/sftp.h
@@ -12,6 +12,7 @@ extern struct module sftp_protocol_module;
 
 #if defined(CONFIG_SFTP) && defined(CONFIG_LIBCURL)
 extern protocol_handler_T sftp_protocol_handler;
+void ftp_curl_handle_error(struct connection *conn, CURLcode res);
 #else
 #define sftp_protocol_handler NULL
 #endif


### PR DESCRIPTION
fixes compilation error when sftp is enabled but ftp is disabled