### PR TITLE
Inlcude the ruby/version.h in ruby.c since it was moved

### DIFF
--- a/src/scripting/ruby/core.c
+++ b/src/scripting/ruby/core.c
@@ -6,7 +6,6 @@
 
 #undef _GNU_SOURCE
 #include <ruby.h>
-#include <ruby/version.h>
 
 #undef _
 

--- a/src/scripting/ruby/ruby.c
+++ b/src/scripting/ruby/ruby.c
@@ -4,6 +4,12 @@
 #include "config.h"
 #endif
 
+#undef _GNU_SOURCE
+#include <ruby.h>
+#include <ruby/version.h>
+
+#undef _
+
 #include "elinks.h"
 
 #include "intl/libintl.h"


### PR DESCRIPTION
When trying to update the version package for openSUSE the build is faling due to missing `ruby/version.h` not being included correctly. This fix the building process.