### PR TITLE
require  quick JS config file

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-
+set -e
 echo aclocal...
 aclocal -I config/m4
 

--- a/configure.ac
+++ b/configure.ac
@@ -709,15 +709,13 @@ case "$with_quickjs" in
 esac
 
 if test "x$CONFIG_QUICKJS" = x; then
-	AC_MSG_CHECKING([for QuickJS])
-	AC_LINK_IFELSE(
-		[AC_LANG_PROGRAM([[
-			#include <quickjs/quickjs.h>
-		]], [])],
-		[CONFIG_QUICKJS=yes
-		 AC_MSG_RESULT([yes])],
-		[AC_MSG_RESULT([not found])]
-	)
+	AC_MSG_CHECKING([for Quick JS config])
+	if $PKG_CONFIG $pkg_config_static --cflags --libs quickjs > /dev/null 2>&AS_MESSAGE_LOG_FD; then
+		CONFIG_QUICKJS=yes
+		AC_MSG_RESULT([yes])
+	else
+		AC_MSG_ERROR([quickjs.pc not found use john-peterson/quickjs@shared or @rope])
+	fi
 
 	if test "x$CONFIG_QUICKJS" = xyes; then
 		DB_LOCALSTORAGE_LIBS="$($PKG_CONFIG $pkg_config_static --libs sqlite3)"
@@ -726,14 +724,8 @@ if test "x$CONFIG_QUICKJS" = x; then
 		CURL_CFLAGS="$($PKG_CONFIG $pkg_config_static --cflags libcurl)"
 
 		CFLAGS="$CFLAGS $DB_LOCALSTORAGE_CFLAGS $XMLPLUSPLUS_CFLAGS $CURL_CFLAGS"
-		QUICKJS_LIB="/usr/local/lib/quickjs/libquickjs.a"
+		QUICKJS_LIB="$($PKG_CONFIG $pkg_config_static --libs quickjs)"
 
-		for p in $(echo "$LIBRARY_PATH" | tr ':' '\n'); do
-			if test -f "$p/quickjs/libquickjs.a" ; then
-				QUICKJS_LIB="$p/quickjs/libquickjs.a"
-				break
-			fi
-		done
 		LIBS="$LIBS $DB_LOCALSTORAGE_LIBS $XMLPLUSPLUS_LIBS $QUICKJS_LIB $CURL_LIBS"
 		CONFIG_LIBCURL=yes
 	else


### PR DESCRIPTION
you can merge it when the config file is merged upstream or build from
my "shared" branch instead quickjs@shared in my account .  if it is declined I will submit it to quickjs-ng instead.
complete madness to look in the dark for a library instead of making a
config file. double madness to use static libs also considering the size
of these libs. we try to reduce the packet size by keeping all files
separate instead of in a gigantic blob of code

cannot understand why this particular lib is made this way when the same
person has made ffmpeg that is famous for absolute zero tolerance for
static libs. talk about one eighty turn. it is impossible to build
ffmpeg if pkg config return a static lib

 # elinks ELF including JS down to one meg! (two with debugging )

when netsurf and quick JS is built shared the program file is only one
meg ! without debugging . compared to around four + two more from JS and netsurf libs. or twelve with debugging

this is for netsurf to also output shared files that are automatically
joined with the config file

 export COMPONENT_TYPE=lib-shared
