### PR TITLE
skip DNS lookup for local files which have empty hostname

### DIFF
--- a/src/document/document.c
+++ b/src/document/document.c
@@ -191,7 +191,8 @@ get_ip(struct document *document)
 	char *host = get_uri_string(uri, URI_DNS_HOST);
 
 	if (host) {
-		find_host(host, &document->querydns, found_dns, &document->ip, 0);
+		if (host[0])
+			find_host(host, &document->querydns, found_dns, &document->ip, 0);
 		mem_free(host);
 	}
 #endif


### PR DESCRIPTION
In case elinks is invoked for a local file, as in `elinks -dump 1 /path/to/file.html`, the hostname portion of the document URI will be the empty string. Avoid firing up the DNS resolver machinery for no reason in this case.

On my machine, when converting a large number of HTML files in bulk using `elinks -dump 1`, this results in a significant speed-up.