### PR TITLE
check declaration of fgets_unlocked for bionic libc

### DIFF
--- a/config/m4/gettext.m4
+++ b/config/m4/gettext.m4
@@ -174,9 +174,10 @@ AC_DEFUN([AM_GNU_GETTEXT],
 
    AC_CHECK_HEADERS([argz.h limits.h locale.h nl_types.h malloc.h stddef.h \
 stdlib.h string.h unistd.h sys/param.h])
-   AC_CHECK_FUNCS([feof_unlocked fgets_unlocked getcwd getegid geteuid \
+   AC_CHECK_FUNCS([feof_unlocked getcwd getegid geteuid \
 getgid getuid mempcpy munmap putenv setenv setlocale stpcpy strchr strcasecmp \
 strdup strtoul tsearch __argz_count __argz_stringify __argz_next])
+   AC_CHECK_DECL([fgets_unlocked])
 
    AM_ICONV
    AM_LANGINFO_CODESET

--- a/src/intl/gettext/localealias.c
+++ b/src/intl/gettext/localealias.c
@@ -38,7 +38,7 @@
 #include "util/memory.h"
 #include "util/string.h"
 
-#ifdef HAVE_FGETS_UNLOCKED
+#ifdef HAVE_DECL_FGETS_UNLOCKED
 #undef fgets
 #define fgets(buf, len, s) fgets_unlocked (buf, len, s)
 #endif


### PR DESCRIPTION
don't assume all functions are declared

different versions hide new functions
