### PR TITLE
Fix parallel build race

### DIFF
--- a/Makefile.lib
+++ b/Makefile.lib
@@ -122,7 +122,7 @@ LIB_O_DEPS = \
  $(sort $(filter-out $(LIB_O_NAME),$(OBJS))) \
  $(foreach subdir,$(sort $(SUBDIRS)),$(wildcard $(subdir)/$(LIB_O_NAME)))
 
-$(LIB_O_NAME): $(LIB_O_DEPS)
+$(LIB_O_NAME): $(LIB_O_DEPS) | all-recursive
 	$(call cmd,ld_objs)
 
 DEP_FILES_1 = $(foreach src,$(OBJS),.deps/$(src))


### PR DESCRIPTION
Fix a parallel-build (-j) race in elinks' hand-written recursive Makefile.

Each directory links its own objects plus the subdirectories' lib.o into one
lib.o (LIB_O_NAME). The subdir lib.o files are built by a separate sub-make
(all-recursive), and the parent only references them through a parse-time
$(wildcard $(subdir)/lib.o) -- empty on a clean tree -- plus a runtime 'test -e'
in cmd_ld_objs. Nothing forces all-recursive to finish first, so the rule
'all: all-recursive all-default all-local' lets the parent's 'ld -r' run
concurrently with the children's 'ld -r': the parent then reads a half-written
subdir/lib.o ("file in wrong format" / truncated) or omits it (undefined refs
at the final link).

The race is scheduling-sensitive, so it mostly bites under heavy load (several
arch builds at once); a lone build or a retry usually gets lucky ordering. Add
an order-only prerequisite so the aggregation waits for the recursion. order-only
avoids needless relinks and keeps the per-directory object compiles fully
parallel -- only the lib.o link step is sequenced.
